### PR TITLE
refactor: prevent import mutation causing build issues with some bundlers

### DIFF
--- a/src/dagre-js/arrows.d.ts
+++ b/src/dagre-js/arrows.d.ts
@@ -1,3 +1,2 @@
-export function normal(parent: any, id: any, edge: any, type: any): void;
-export function vee(parent: any, id: any, edge: any, type: any): void;
-export function undirected(parent: any, id: any, edge: any, type: any): void;
+export var arrows: any;
+export function setArrows(value: any): any;

--- a/src/dagre-js/arrows.js
+++ b/src/dagre-js/arrows.js
@@ -1,9 +1,18 @@
 import * as util from "./util";
 
 export {
+  arrows,
+  setArrows,
+};
+
+var arrows = {
   normal,
   vee,
   undirected
+};
+
+function setArrows(value) {
+  arrows = value;
 };
 
 function normal(parent, id, edge, type) {

--- a/src/dagre-js/create-clusters.d.ts
+++ b/src/dagre-js/create-clusters.d.ts
@@ -1,1 +1,2 @@
 export function createClusters(selection: any, g: any): any;
+export function setCreateClusters(value: any): any;

--- a/src/dagre-js/create-clusters.js
+++ b/src/dagre-js/create-clusters.js
@@ -2,9 +2,9 @@ import * as d3 from "d3";
 import { addLabel } from "./label/add-label";
 import * as util from "./util";
 
-export { createClusters };
+export { createClusters, setCreateClusters };
 
-function createClusters(selection, g) {
+var createClusters = function (selection, g) {
   var clusters = g.nodes().filter(function (v) { return util.isSubgraph(g, v); });
   var svgClusters = selection.selectAll("g.cluster")
     .data(clusters, function (v) { return v; });
@@ -40,4 +40,8 @@ function createClusters(selection, g) {
   });
 
   return svgClusters;
+}
+
+function setCreateClusters(value) {
+  createClusters = value;
 }

--- a/src/dagre-js/create-edge-labels.d.ts
+++ b/src/dagre-js/create-edge-labels.d.ts
@@ -1,1 +1,2 @@
 export function createEdgeLabels(selection: any, g: any): any;
+export function setCreateEdgeLabels(value: any): any;

--- a/src/dagre-js/create-edge-labels.js
+++ b/src/dagre-js/create-edge-labels.js
@@ -3,9 +3,9 @@ import _ from 'lodash-es';
 import { addLabel } from "./label/add-label";
 import * as util from "./util";
 
-export { createEdgeLabels };
+export { createEdgeLabels, setCreateEdgeLabels };
 
-function createEdgeLabels(selection, g) {
+var createEdgeLabels = function(selection, g) {
   var svgEdgeLabels = selection.selectAll("g.edgeLabel")
     .data(g.edges(), function (e) { return util.edgeToId(e); })
     .classed("update", true);
@@ -42,4 +42,8 @@ function createEdgeLabels(selection, g) {
     .remove();
 
   return svgEdgeLabels;
+}
+
+function setCreateEdgeLabels(value) {
+  setCreateEdgeLabels = value;
 }

--- a/src/dagre-js/create-edge-paths.d.ts
+++ b/src/dagre-js/create-edge-paths.d.ts
@@ -1,1 +1,2 @@
 export function createEdgePaths(selection: any, g: any, arrows: any): any;
+export function setCreateEdgePaths(value: any): any;

--- a/src/dagre-js/create-edge-paths.js
+++ b/src/dagre-js/create-edge-paths.js
@@ -3,9 +3,9 @@ import _ from 'lodash-es';
 import { intersectNode } from "./intersect/intersect-node";
 import * as util from "./util";
 
-export { createEdgePaths };
+export { createEdgePaths, setCreateEdgePaths };
 
-function createEdgePaths(selection, g, arrows) {
+var createEdgePaths = function(selection, g, arrows) {
   var previousPaths = selection.selectAll("g.edgePath")
     .data(g.edges(), function (e) { return util.edgeToId(e); })
     .classed("update", true);
@@ -57,6 +57,10 @@ function createEdgePaths(selection, g, arrows) {
     });
 
   return svgPaths;
+}
+
+function setCreateEdgePaths(value) {
+  createEdgePaths = value;
 }
 
 function makeFragmentRef(url, fragmentId) {

--- a/src/dagre-js/create-nodes.d.ts
+++ b/src/dagre-js/create-nodes.d.ts
@@ -1,1 +1,2 @@
 export function createNodes(selection: any, g: any, shapes: any): any;
+export function setCreateNodes(value: any): any;

--- a/src/dagre-js/create-nodes.js
+++ b/src/dagre-js/create-nodes.js
@@ -3,9 +3,9 @@ import _ from 'lodash-es';
 import { addLabel } from "./label/add-label";
 import * as util from "./util";
 
-export { createNodes };
+export { createNodes, setCreateNodes };
 
-function createNodes(selection, g, shapes) {
+var createNodes = function(selection, g, shapes) {
   var simpleNodes = g.nodes().filter(function (v) { return !util.isSubgraph(g, v); });
   var svgNodes = selection.selectAll("g.node")
     .data(simpleNodes, function (v) { return v; })
@@ -68,4 +68,9 @@ function createNodes(selection, g, shapes) {
     .remove();
 
   return svgNodes;
+}
+
+
+function setCreateNodes(value) {
+  createNodes = value;
 }

--- a/src/dagre-js/render.d.ts
+++ b/src/dagre-js/render.d.ts
@@ -1,6 +1,6 @@
 export function render(): {
     (svg: any, g: any): void;
-    createNodes(value: any, ...args: any[]): typeof createNodes;
+    createNodes(...args: any[]): typeof createNodes;
     createClusters(value: any, ...args: any[]): typeof createClusters;
     createEdgeLabels(value: any, ...args: any[]): typeof createEdgeLabels;
     createEdgePaths(value: any, ...args: any[]): typeof createEdgePaths;

--- a/src/dagre-js/render.js
+++ b/src/dagre-js/render.js
@@ -1,15 +1,15 @@
 import * as d3 from "d3";
 import _ from 'lodash-es';
 import { layout } from "../dagre/index";
-import * as arrows from "./arrows";
-import { createClusters } from "./create-clusters";
-import { createEdgeLabels } from "./create-edge-labels";
-import { createEdgePaths } from "./create-edge-paths";
-import { createNodes } from "./create-nodes";
+import { arrows, setArrows } from "./arrows";
+import { createClusters, setCreateClusters } from "./create-clusters";
+import { createEdgeLabels, setCreateEdgeLabels } from "./create-edge-labels";
+import { createEdgePaths, setCreateEdgePaths } from "./create-edge-paths";
+import { createNodes, setCreateNodes } from "./create-nodes";
 import { positionClusters } from "./position-clusters";
 import { positionEdgeLabels } from "./position-edge-labels";
 import { positionNodes } from "./position-nodes";
-import * as shapes from "./shapes";
+import { shapes, setShapes } from "./shapes";
 
 export { render };
 
@@ -38,37 +38,37 @@ function render() {
 
   fn.createNodes = function (value) {
     if (!arguments.length) return createNodes;
-    createNodes = value;
+    setCreateNodes(value);
     return fn;
   };
 
   fn.createClusters = function (value) {
     if (!arguments.length) return createClusters;
-    createClusters = value;
+    setCreateClusters(value);
     return fn;
   };
 
   fn.createEdgeLabels = function (value) {
     if (!arguments.length) return createEdgeLabels;
-    createEdgeLabels = value;
+    setCreateEdgeLabels(value);
     return fn;
   };
 
   fn.createEdgePaths = function (value) {
     if (!arguments.length) return createEdgePaths;
-    createEdgePaths = value;
+    setCreateEdgePaths(value);
     return fn;
   };
 
   fn.shapes = function (value) {
     if (!arguments.length) return shapes;
-    shapes = value;
+    setShapes(value);
     return fn;
   };
 
   fn.arrows = function (value) {
     if (!arguments.length) return arrows;
-    arrows = value;
+    setArrows(value);
     return fn;
   };
 

--- a/src/dagre-js/shapes.d.ts
+++ b/src/dagre-js/shapes.d.ts
@@ -1,4 +1,2 @@
-export function rect(parent: any, bbox: any, node: any): any;
-export function ellipse(parent: any, bbox: any, node: any): any;
-export function circle(parent: any, bbox: any, node: any): any;
-export function diamond(parent: any, bbox: any, node: any): any;
+export var shapes: any;
+export function setShapes(value: any): any;

--- a/src/dagre-js/shapes.js
+++ b/src/dagre-js/shapes.js
@@ -4,11 +4,20 @@ import { intersectPolygon } from "./intersect/intersect-polygon";
 import { intersectRect } from "./intersect/intersect-rect";
 
 export {
+  shapes,
+  setShapes
+};
+
+var shapes = {
   rect,
   ellipse,
   circle,
   diamond
 };
+
+function setShapes(value) {
+  shapes = value;
+}
 
 function rect(parent, bbox, node) {
   var shapeSvg = parent.insert("rect", ":first-child")


### PR DESCRIPTION
Javascript allow mutation for imported objects. But its's important to keep the code as mutation free as possible.
Moreover, some module bundlers with dependencies optimizations don't accept that and throw error. (Rollup, Vite..) 