### PR TITLE
fix: `lodash-es` tree-shakeable import.

### DIFF
--- a/src/dagre-js/create-edge-labels.js
+++ b/src/dagre-js/create-edge-labels.js
@@ -1,5 +1,5 @@
 import * as d3 from "d3";
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import { addLabel } from "./label/add-label";
 import * as util from "./util";
 

--- a/src/dagre-js/create-edge-paths.js
+++ b/src/dagre-js/create-edge-paths.js
@@ -1,5 +1,5 @@
 import * as d3 from "d3";
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import { intersectNode } from "./intersect/intersect-node";
 import * as util from "./util";
 

--- a/src/dagre-js/create-nodes.js
+++ b/src/dagre-js/create-nodes.js
@@ -1,5 +1,5 @@
 import * as d3 from "d3";
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import { addLabel } from "./label/add-label";
 import * as util from "./util";
 

--- a/src/dagre-js/position-edge-labels.js
+++ b/src/dagre-js/position-edge-labels.js
@@ -1,5 +1,5 @@
 import * as d3 from "d3";
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import * as util from "./util";
 
 export { positionEdgeLabels };

--- a/src/dagre-js/render.js
+++ b/src/dagre-js/render.js
@@ -1,5 +1,5 @@
 import * as d3 from "d3";
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import { layout } from "../dagre/index";
 import { arrows, setArrows } from "./arrows";
 import { createClusters, setCreateClusters } from "./create-clusters";

--- a/src/dagre-js/util.js
+++ b/src/dagre-js/util.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 
 // Public utility functions
 export {

--- a/src/dagre/acyclic.js
+++ b/src/dagre/acyclic.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import { greedyFAS } from "./greedy-fas";
 
 export {

--- a/src/dagre/add-border-segments.js
+++ b/src/dagre/add-border-segments.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import * as util from "./util";
 
 export { addBorderSegments };

--- a/src/dagre/coordinate-system.js
+++ b/src/dagre/coordinate-system.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 
 export {
   adjust,

--- a/src/dagre/debug.js
+++ b/src/dagre/debug.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import { Graph } from "./graphlib";
 import * as util from "./util";
 

--- a/src/dagre/greedy-fas.js
+++ b/src/dagre/greedy-fas.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import { Graph } from '../graphlib/index';
 import { List } from "./data/list";
 

--- a/src/dagre/layout.js
+++ b/src/dagre/layout.js
@@ -1,6 +1,6 @@
 
 
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import { Graph } from '../graphlib';
 import { addBorderSegments } from "./add-border-segments";
 import * as coordinateSystem from "./coordinate-system";

--- a/src/dagre/nesting-graph.js
+++ b/src/dagre/nesting-graph.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import * as util from "./util";
 
 export {

--- a/src/dagre/normalize.js
+++ b/src/dagre/normalize.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import * as util from "./util";
 
 export {

--- a/src/dagre/order/add-subgraph-constraints.js
+++ b/src/dagre/order/add-subgraph-constraints.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 
 export { addSubgraphConstraints };
 

--- a/src/dagre/order/barycenter.js
+++ b/src/dagre/order/barycenter.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 
 export { barycenter };
 

--- a/src/dagre/order/build-layer-graph.js
+++ b/src/dagre/order/build-layer-graph.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import { Graph } from "../../graphlib";
 
 export { buildLayerGraph };

--- a/src/dagre/order/cross-count.js
+++ b/src/dagre/order/cross-count.js
@@ -1,6 +1,6 @@
 
 
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 
 export { crossCount };
 

--- a/src/dagre/order/index.js
+++ b/src/dagre/order/index.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import { Graph } from "../../graphlib";
 import * as util from "../util";
 import { addSubgraphConstraints } from "./add-subgraph-constraints";

--- a/src/dagre/order/init-order.js
+++ b/src/dagre/order/init-order.js
@@ -1,6 +1,6 @@
 
 
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 
 export { initOrder };
 

--- a/src/dagre/order/resolve-conflicts.js
+++ b/src/dagre/order/resolve-conflicts.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 
 export { resolveConflicts };
 

--- a/src/dagre/order/sort-subgraph.js
+++ b/src/dagre/order/sort-subgraph.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import { barycenter } from "./barycenter";
 import { resolveConflicts } from "./resolve-conflicts";
 import { sort } from "./sort";

--- a/src/dagre/order/sort.js
+++ b/src/dagre/order/sort.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import * as util from "../util";
 
 export { sort };

--- a/src/dagre/parent-dummy-chains.js
+++ b/src/dagre/parent-dummy-chains.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 
 export { parentDummyChains };
 

--- a/src/dagre/position/bk.js
+++ b/src/dagre/position/bk.js
@@ -1,6 +1,6 @@
 
 
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import { Graph } from "../../graphlib";
 import * as util from "../util";
 

--- a/src/dagre/position/index.js
+++ b/src/dagre/position/index.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import * as util from "../util";
 import { positionX } from "./bk";
 

--- a/src/dagre/rank/feasible-tree.js
+++ b/src/dagre/rank/feasible-tree.js
@@ -1,6 +1,6 @@
 
 
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import { Graph } from "../../graphlib";
 import { slack } from "./util";
 

--- a/src/dagre/rank/network-simplex.js
+++ b/src/dagre/rank/network-simplex.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import * as alg from "../../graphlib/alg";
 import { simplify } from "../util";
 import { feasibleTree } from "./feasible-tree";

--- a/src/dagre/rank/util.js
+++ b/src/dagre/rank/util.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 
 export {
   longestPath,

--- a/src/dagre/util.js
+++ b/src/dagre/util.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import { Graph } from "../graphlib";
 
 export {

--- a/src/graphlib/alg/components.js
+++ b/src/graphlib/alg/components.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 
 export { components };
 

--- a/src/graphlib/alg/dfs.js
+++ b/src/graphlib/alg/dfs.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 
 export { dfs };
 

--- a/src/graphlib/alg/dijkstra-all.js
+++ b/src/graphlib/alg/dijkstra-all.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import { dijkstra } from "./dijkstra";
 
 export { dijkstraAll };

--- a/src/graphlib/alg/dijkstra.js
+++ b/src/graphlib/alg/dijkstra.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import * as PriorityQueue from "../data/priority-queue";
 
 

--- a/src/graphlib/alg/find-cycles.js
+++ b/src/graphlib/alg/find-cycles.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import { tarjan } from "./tarjan";
 
 export { findCycles };

--- a/src/graphlib/alg/floyd-warshall.js
+++ b/src/graphlib/alg/floyd-warshall.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 
 export { floydWarshall };
 

--- a/src/graphlib/alg/prim.js
+++ b/src/graphlib/alg/prim.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import { PriorityQueue } from "../data/priority-queue";
 import { Graph } from "../graph";
 

--- a/src/graphlib/alg/tarjan.js
+++ b/src/graphlib/alg/tarjan.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 
 export { tarjan };
 

--- a/src/graphlib/alg/topsort.js
+++ b/src/graphlib/alg/topsort.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 
 export { topsort, CycleException };
 

--- a/src/graphlib/data/priority-queue.js
+++ b/src/graphlib/data/priority-queue.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 
 export { PriorityQueue };
 

--- a/src/graphlib/graph.js
+++ b/src/graphlib/graph.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 
 var DEFAULT_EDGE_NAME = "\x00";
 var GRAPH_NODE = "\x00";

--- a/src/graphlib/json.js
+++ b/src/graphlib/json.js
@@ -1,4 +1,4 @@
-import _ from 'lodash-es';
+import * as _ from 'lodash-es';
 import { Graph } from './graph';
 
 export { write, read };


### PR DESCRIPTION
This enables vite to tree-shake lodash and reduce bundle size.

| Bundle           | Initial | After dagre-es | After import fix | Change   | % Change |
| ---------------- | ------- | -------------- | --------- | -------- | -------- |
| mermaid.js       | 2055.7  | 1839.41        | 1694.35   | \-361.35 | \-17.58  |
| mermaid.core.mjs | 1080.32 | 1313.80        | 1178.73   | +98.41   | +9.11    |
