### PR TITLE
Add a basic GitHub actions for checking `prettier` formatting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - run: npm ci # throws an error if the package-lock.json file is out of sync
+      - name: Check for prettier errors (run `npm run format` to fix)
+        run: npx prettier --check .

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  singleQuote: true,
+  printWidth: 100,
+};


### PR DESCRIPTION
Adds a basic GitHub Action workflow that just runs `prettier --check .` and fails if any files haven't been formatted with prettier.

GitHub Actions is a continuous integration provider from GitHub that is free for public repositories:

> GitHub Actions usage is free for standard GitHub-hosted runners in public repositories
>
> _Taken from https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#about-billing-for-github-actions_

On GitHub, you will get a little green tick by your commit if all CI passed, or a red cross if anything failed:

![image](https://user-images.githubusercontent.com/19716675/205461733-dedcc307-15e1-49d7-88cf-a8b53c363ffe.png)

Viewing the CI output will show the step that failed (e.g. if the command returned a non-zero exit code), and the output of that step:

![image](https://user-images.githubusercontent.com/19716675/205461756-a75b9e54-f6c6-4ed3-a525-9e18d67e27e6.png)

This should make reviewing pull requests from other people easier, since GitHub should do some of the work for you!

In the future, it might be useful to copy over some of the automated tests from the https://github.com/dagrejs/graphlib library, and use them too, but that can be future work!

---

Btw, I had to add a custom prettier config to get the same output as was created in https://github.com/tbo47/dagre-es/commit/c888afa7653ce828ca9bb3f1b1bce8d10f02cd3f.

I just guessed some values that don't change anything, but if there are different values you want to use, feel free to modify them!