### PR TITLE
Add `type: module`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Thibaut Lassalle",
   "license": "MIT",
   "main": "src/index.js",
+  "type": "module",
   "scripts": {
     "generate_types": "tsc src/*.js --declaration --allowJs --emitDeclarationOnly",
     "compile_js_as_ts": "tsc src/index.js --AllowJs --checkJs --outDir dist/"


### PR DESCRIPTION
dagre-d3-es doesn't appear to be written in CJS, but also doesn't appear to be a valid ES module (i.e. it doesn't have "type": "module" or an .mjs extension for the entry point). Please contact the package author to fix.


Error found in https://github.com/mermaid-js/mermaid-live-editor/pull/1119