### PR TITLE
docs: create LICENSE.md file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,23 @@
+Original dagre-d3 copyright: Copyright (c) 2013 Chris Pettitt
+Original dagre copyright: Copyright (c) 2012-2014 Chris Pettitt
+Original graphlib copyright: Copyright (c) 2012-2014 Chris Pettitt
+
+Copyright (c) 2022-2023 Thibaut Lassalle and dagre-es contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
Create a `LICENSE.md` file that contains the original copyright messages from:
  - [dagre-d3][1]
  - [dagre][2]
  - [graphlib][3]

[1]: https://github.com/dagrejs/dagre-d3/blob/10e37c786fd8d1162c052308bde67e6171b67543/LICENSE
[2]: https://github.com/dagrejs/dagre/blob/103136b04a13c7ac10d8ded25954da58d5ed88e1/LICENSE
[3]: https://github.com/dagrejs/graphlib/blob/62f5f6406592fa43fac968685f9ac8cbcfd92c2a/LICENSE

Under the MIT license, we need to copy all of copyright notices, see the line:

> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.