### PR TITLE
build: fix TypeScript `prepack` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "main": "src/index.js",
   "type": "module",
   "scripts": {
-    "generate_types": "find . -name '*.d.ts' -type f -delete ; tsc --build",
-    "___prepack": "npm run generate_types",
+    "generate_types": "find src -name '*.d.ts' -type f -delete ; tsc --build",
+    "prepack": "npm run generate_types",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "format": "prettier --write .",

--- a/src/dagre-js/render.js
+++ b/src/dagre-js/render.js
@@ -94,6 +94,8 @@ var EDGE_DEFAULT_ATTRS = {
  * @typedef {Object} Node
  * @property {string} label - The label of the node.
  * @property {number} [paddingX] - The horizontal padding of the node.
+ * @property {number} [paddingY] - The vertical padding of the node.
+ * @property {number} [padding] - The padding of the node for all directions. Overrides `paddingX` and `paddingY`.
  * @property {number} [paddingLeft] - The left padding of the node.
  * @property {number} [paddingRight] - The right padding of the node.
  * @property {number} [_prevWidth]

--- a/src/dagre/normalize.js
+++ b/src/dagre/normalize.js
@@ -1,3 +1,8 @@
+/**
+ * TypeScript type imports:
+ *
+ * @import { Graph } from '../graphlib/graph.js';
+ */
 import * as util from './util.js';
 
 export { run, undo };
@@ -23,6 +28,9 @@ function run(g) {
   g.edges().forEach((edge) => normalizeEdge(g, edge));
 }
 
+/**
+ * @param {Graph} g
+ */
 function normalizeEdge(g, e) {
   var v = e.v;
   var vRank = g.node(v).rank;
@@ -36,7 +44,20 @@ function normalizeEdge(g, e) {
 
   g.removeEdge(e);
 
-  var dummy, attrs, i;
+  /**
+   * @typedef {Object} Attrs
+   * @property {number} width
+   * @property {number} height
+   * @property {ReturnType<Graph["node"]>} edgeLabel
+   * @property {any} edgeObj
+   * @property {ReturnType<Graph["node"]>["rank"]} rank
+   * @property {string} [dummy]
+   * @property {ReturnType<Graph["node"]>["labelpos"]} [labelpos]
+   */
+
+  /** @type {Attrs | undefined} */
+  var attrs = undefined;
+  var dummy, i;
   for (i = 0, ++vRank; vRank < wRank; ++i, ++vRank) {
     edgeLabel.points = [];
     attrs = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,12 +3,14 @@
     "checkJs": true,
     "declaration": true,
     "emitDeclarationOnly": true,
-    "lib": ["dom", "dom.iterable", "es2022"],
+    "lib": ["dom", "dom.iterable", "es2020"],
     "types": [
       // vitest types don't work with module "node16", see
       // https://github.com/vitejs/vite/issues/11552
       "@types/jest"
     ],
     "module": "node16"
-  }
+  },
+  "include": ["src/**/*.js"],
+  "exclude": ["src/**/*.test.js"]
 }


### PR DESCRIPTION
Fix the TypeScript `npm run generate_types` command by:

- Only deleting files in the `src/` dir, not in the `node_modules` dir
- Skipping building the types from `.test.js` files
- Fixing some type errors caused by https://github.com/tbo47/dagre-es/commit/e03371f2ee986cd30ac5b3229e18816980e8fb7d

I've also reverted the TypeScript ES2020 version that was used before https://github.com/tbo47/dagre-es/commit/e03371f2ee986cd30ac5b3229e18816980e8fb7d, since we're not using any ES2022 features, and if we do start using them, I'm worried it might be a breaking change for users.
