### PR TITLE
use offsetWidth and offsetHeight to handle zooming

### DIFF
--- a/src/dagre-js/label/add-html-label.js
+++ b/src/dagre-js/label/add-html-label.js
@@ -30,6 +30,6 @@ function addHtmlLabel(root, node) {
 
   var client = div.node();
   fo.attr('width', client.offsetWidth).attr('height', client.offsetHeight);
-  
+
   return fo;
 }

--- a/src/dagre-js/label/add-html-label.js
+++ b/src/dagre-js/label/add-html-label.js
@@ -28,8 +28,8 @@ function addHtmlLabel(root, node) {
   // Fix for firefox
   div.style('white-space', 'nowrap');
 
-  var client = div.node().getBoundingClientRect();
-  fo.attr('width', client.width).attr('height', client.height);
-
+  var client = div.node();
+  fo.attr('width', client.offsetWidth).attr('height', client.offsetHeight);
+  
   return fo;
 }


### PR DESCRIPTION
previously if the node was created in a zoomed container, it would be incorrectly sized