### PR TITLE
fix: Prototype Pollution

### DIFF
--- a/src/dagre/position/bk.js
+++ b/src/dagre/position/bk.js
@@ -38,6 +38,7 @@ export {
  * single node in the layers being scanned.
  */
 function findType1Conflicts(g, layering) {
+  /** @type {{[nodeId: string | number]: {[nodeId: string | number]: true}}} */
   var conflicts = {};
 
   function visitLayer(prevLayer, layer) {
@@ -78,6 +79,7 @@ function findType1Conflicts(g, layering) {
 }
 
 function findType2Conflicts(g, layering) {
+  /** @type {{[nodeId: string | number]: {[nodeId: string | number]: true}}} */
   var conflicts = {};
 
   function scan(south, southPos, southEnd, prevNorthBorder, nextNorthBorder) {
@@ -130,35 +132,33 @@ function findOtherInnerSegmentNode(g, v) {
 }
 
 /**
- * Validates that a key is safe to use as an object property.
- * Prevents prototype pollution by rejecting proto.
- * @param {*} key - The key to validate
- * @returns {boolean} True if the key is safe to use
+ * Sets `conflicts[v][w] = true`, creating objects if needed.
+ *
+ * @param {{[nodeId: string | number]: {[nodeId: string | number]: true}}} conflicts - Object to set.
+ * @param {string | number} v - First Node ID
+ * @param {string | number} w - Second Node ID
  */
-function isSafeKey(key) {
-  if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
-    return false;
-  }
-  const keyType = typeof key;
-  return keyType === 'string' || keyType === 'number';
-}
-
 function addConflict(conflicts, v, w) {
-  if (!isSafeKey(v) || !isSafeKey(w)) {
-    return;
-  }
-
   if (v > w) {
     var tmp = v;
     v = w;
     w = tmp;
   }
 
-  var conflictsV = conflicts[v];
-  if (!conflictsV) {
-    conflicts[v] = conflictsV = {};
+  if (!Object.prototype.hasOwnProperty.call(conflicts, v)) {
+    // can't use conflicts[v] = {} since it's unsafe if v = `__proto__`
+    Object.defineProperty(conflicts, v, {
+      enumerable: true,
+      configurable: true,
+      value: {},
+    });
   }
-  conflictsV[w] = true;
+  var conflictsV = conflicts[v];
+  Object.defineProperty(conflictsV, w, {
+    enumerable: true,
+    configurable: true,
+    value: true,
+  });
 }
 
 function hasConflict(conflicts, v, w) {

--- a/src/dagre/position/bk.js
+++ b/src/dagre/position/bk.js
@@ -129,7 +129,25 @@ function findOtherInnerSegmentNode(g, v) {
   }
 }
 
+/**
+ * Validates that a key is safe to use as an object property.
+ * Prevents prototype pollution by rejecting proto.
+ * @param {*} key - The key to validate
+ * @returns {boolean} True if the key is safe to use
+ */
+function isSafeKey(key) {
+  if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+    return false;
+  }
+  const keyType = typeof key;
+  return keyType === 'string' || keyType === 'number';
+}
+
 function addConflict(conflicts, v, w) {
+  if (!isSafeKey(v) || !isSafeKey(w)) {
+    return;
+  }
+
   if (v > w) {
     var tmp = v;
     v = w;

--- a/src/dagre/position/bk.js
+++ b/src/dagre/position/bk.js
@@ -151,6 +151,7 @@ function addConflict(conflicts, v, w) {
       enumerable: true,
       configurable: true,
       value: {},
+      writable: true,
     });
   }
   var conflictsV = conflicts[v];
@@ -158,6 +159,7 @@ function addConflict(conflicts, v, w) {
     enumerable: true,
     configurable: true,
     value: true,
+    writable: true,
   });
 }
 

--- a/src/dagre/position/bk.test.js
+++ b/src/dagre/position/bk.test.js
@@ -163,6 +163,13 @@ describe('position/bk', function () {
       expect(hasConflict(conflicts, 'a', 'b')).to.be.true;
       expect(hasConflict(conflicts, 'a', 'c')).to.be.true;
     });
+
+    it('works for nodes named __proto__', function () {
+      var conflicts = {};
+      addConflict(conflicts, '__proto__', 'myAdminKey');
+      expect(hasConflict(conflicts, '__proto__', 'myAdminKey')).to.be.true;
+      expect({}).not.to.have.property('myAdminKey');
+    });
   });
 
   describe('verticalAlignment', function () {


### PR DESCRIPTION
This PR addresses a prototype pollution vulnerability (CVE-2025-57347, CWE-1321) in the addConflict() function within src/dagre/position/bk.js. The vulnerability allowed attackers to inject malicious property keys like __proto__ to modify the JavaScript Object prototype chain, potentially leading to denial of service, application crashes, or arbitrary code execution.

This approach:

- Prevents prototype pollution by using explicit property descriptors
- Allows legitimate use of __proto__, constructor, and prototype as node IDs in graphs
- Maintains backward compatibility with existing functionality

Resolves #52 