### PR TITLE
Fix prototype pollution vulnerability in addConflict function

### DIFF
--- a/src/dagre/position/bk.js
+++ b/src/dagre/position/bk.js
@@ -146,11 +146,12 @@ function addConflict(conflicts, v, w) {
   }
 
   if (!Object.prototype.hasOwnProperty.call(conflicts, v)) {
-    // can't use conflicts[v] = {} since it's unsafe if v = `__proto__`
+    // Use Object.create(null) to create an object without prototype chain
+    // This prevents prototype pollution even if v = `__proto__` or other dangerous keys
     Object.defineProperty(conflicts, v, {
       enumerable: true,
       configurable: true,
-      value: {},
+      value: Object.create(null),
       writable: true,
     });
   }


### PR DESCRIPTION
Replace plain object literal {} with Object.create(null) to prevent prototype pollution attacks. The nested conflict objects now use null-prototype objects which are immune to prototype chain manipulation even when attacker-controlled keys like '__proto__' are used.

This addresses CVE reported at:
https://security.snyk.io/package/npm/dagre-d3-es/7.0.13

All existing tests pass, including the __proto__ test case.