### PR TITLE
Add types using JSDoc to the `graphlib` file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,9 @@ jobs:
         run: npm run lint
       - name: Check for prettier errors (run `npm run format` to fix)
         run: npx prettier --check .
+      - name: Check typescript types
+        # this is not the same as building, since this also checks unit tests
+        run: npx tsc
       - name: Run unit tests
         run: npm test
       - name: Build the npm package to publish

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "bundle": "chmod +x bundle.sh ; ./bundle.sh && cp dist/dagre-d3*.js ../tbo47.github.io",
-    "generate_types": "find src -name '*.d.ts' -type f -delete ; tsc --build",
+    "generate_types": "find src -name '*.d.ts' -type f -delete ; tsc --project tsconfig.build.json",
     "prepack": "npm run generate_types",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",

--- a/src/dagre/acyclic.test.js
+++ b/src/dagre/acyclic.test.js
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import * as acyclic from './acyclic.js';
 import { Graph } from '../graphlib/index.js';

--- a/src/dagre/acyclic.test.js
+++ b/src/dagre/acyclic.test.js
@@ -7,6 +7,7 @@ import { findCycles } from '../graphlib/alg/find-cycles.js';
 
 describe('acyclic', function () {
   var ACYCLICERS = ['greedy', 'dfs', 'unknown-should-still-work'];
+  /** @type {Graph} */
   var g;
 
   beforeEach(function () {

--- a/src/dagre/add-border-segments.test.js
+++ b/src/dagre/add-border-segments.test.js
@@ -3,6 +3,7 @@ import { addBorderSegments } from './add-border-segments.js';
 import { Graph } from '../graphlib/index.js';
 
 describe('addBorderSegments', function () {
+  /** @type {Graph} */
   var g;
 
   beforeEach(function () {

--- a/src/dagre/add-border-segments.test.js
+++ b/src/dagre/add-border-segments.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { addBorderSegments } from './add-border-segments.js';
 import { Graph } from '../graphlib/index.js';
 

--- a/src/dagre/coordinate-system.test.js
+++ b/src/dagre/coordinate-system.test.js
@@ -1,6 +1,6 @@
 import { Graph } from '../graphlib/index.js';
 import * as coordinateSystem from './coordinate-system.js';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 describe('coordinateSystem', function () {
   var g;

--- a/src/dagre/coordinate-system.test.js
+++ b/src/dagre/coordinate-system.test.js
@@ -3,6 +3,7 @@ import * as coordinateSystem from './coordinate-system.js';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 describe('coordinateSystem', function () {
+  /** @type {Graph} */
   var g;
 
   beforeEach(function () {

--- a/src/dagre/data/list.test.js
+++ b/src/dagre/data/list.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { List } from './list.js';
 

--- a/src/dagre/greedy-fas.test.js
+++ b/src/dagre/greedy-fas.test.js
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { Graph } from '../graphlib/index.js';
 import { findCycles } from '../graphlib/alg/find-cycles.js';

--- a/src/dagre/greedy-fas.test.js
+++ b/src/dagre/greedy-fas.test.js
@@ -6,6 +6,7 @@ import { findCycles } from '../graphlib/alg/find-cycles.js';
 import { greedyFAS } from './greedy-fas.js';
 
 describe('greedyFAS', function () {
+  /** @type {Graph} */
   var g;
 
   beforeEach(function () {

--- a/src/dagre/layout.test.js
+++ b/src/dagre/layout.test.js
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { layout } from './layout.js';
 import { Graph } from '../graphlib/index.js';

--- a/src/dagre/layout.test.js
+++ b/src/dagre/layout.test.js
@@ -5,6 +5,7 @@ import { layout } from './layout.js';
 import { Graph } from '../graphlib/index.js';
 
 describe('layout', function () {
+  /** @type {Graph} */
   var g;
 
   beforeEach(function () {

--- a/src/dagre/nesting-graph.test.js
+++ b/src/dagre/nesting-graph.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { Graph } from '../graphlib/index.js';
 import { components } from '../graphlib/alg/components.js';

--- a/src/dagre/nesting-graph.test.js
+++ b/src/dagre/nesting-graph.test.js
@@ -5,6 +5,7 @@ import { components } from '../graphlib/alg/components.js';
 import * as nestingGraph from './nesting-graph.js';
 
 describe('rank/nestingGraph', function () {
+  /** @type {Graph} */
   var g;
 
   beforeEach(function () {

--- a/src/dagre/normalize.test.js
+++ b/src/dagre/normalize.test.js
@@ -5,6 +5,7 @@ import * as normalize from './normalize.js';
 import { Graph } from '../graphlib/index.js';
 
 describe('normalize', function () {
+  /** @type {Graph} */
   var g;
 
   beforeEach(function () {

--- a/src/dagre/normalize.test.js
+++ b/src/dagre/normalize.test.js
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import * as normalize from './normalize.js';
 import { Graph } from '../graphlib/index.js';

--- a/src/dagre/order/add-subgraph-constraints.test.js
+++ b/src/dagre/order/add-subgraph-constraints.test.js
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { Graph } from '../../graphlib/graph.js';
 import { addSubgraphConstraints } from './add-subgraph-constraints.js';

--- a/src/dagre/order/add-subgraph-constraints.test.js
+++ b/src/dagre/order/add-subgraph-constraints.test.js
@@ -5,7 +5,10 @@ import { Graph } from '../../graphlib/graph.js';
 import { addSubgraphConstraints } from './add-subgraph-constraints.js';
 
 describe('order/addSubgraphConstraints', function () {
-  var g, cg;
+  /** @type {Graph} */
+  var g;
+  /** @type {Graph} */
+  var cg;
 
   beforeEach(function () {
     g = new Graph({ compound: true });

--- a/src/dagre/order/barycenter.test.js
+++ b/src/dagre/order/barycenter.test.js
@@ -4,6 +4,7 @@ import { barycenter } from './barycenter.js';
 import { Graph } from '../../graphlib/graph.js';
 
 describe('order/barycenter', function () {
+  /** @type {Graph} */
   var g;
 
   beforeEach(function () {

--- a/src/dagre/order/barycenter.test.js
+++ b/src/dagre/order/barycenter.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { barycenter } from './barycenter.js';
 import { Graph } from '../../graphlib/graph.js';

--- a/src/dagre/order/build-layer-graph.test.js
+++ b/src/dagre/order/build-layer-graph.test.js
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { Graph } from '../../graphlib/graph.js';
 import { buildLayerGraph } from './build-layer-graph.js';

--- a/src/dagre/order/build-layer-graph.test.js
+++ b/src/dagre/order/build-layer-graph.test.js
@@ -5,6 +5,7 @@ import { Graph } from '../../graphlib/graph.js';
 import { buildLayerGraph } from './build-layer-graph.js';
 
 describe('order/buildLayerGraph', function () {
+  /** @type {Graph} */
   var g;
 
   beforeEach(function () {

--- a/src/dagre/order/cross-count.test.js
+++ b/src/dagre/order/cross-count.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { Graph } from '../../graphlib/graph.js';
 import { crossCount } from './cross-count.js';

--- a/src/dagre/order/cross-count.test.js
+++ b/src/dagre/order/cross-count.test.js
@@ -4,6 +4,7 @@ import { Graph } from '../../graphlib/graph.js';
 import { crossCount } from './cross-count.js';
 
 describe('crossCount', function () {
+  /** @type {Graph} */
   var g;
 
   beforeEach(function () {

--- a/src/dagre/order/index.test.js
+++ b/src/dagre/order/index.test.js
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { Graph } from '../../graphlib/graph.js';
 import { order } from './index.js';

--- a/src/dagre/order/index.test.js
+++ b/src/dagre/order/index.test.js
@@ -7,6 +7,7 @@ import { crossCount } from './cross-count.js';
 import { buildLayerMatrix } from '../util.js';
 
 describe('order', function () {
+  /** @type {Graph} */
   var g;
 
   beforeEach(function () {

--- a/src/dagre/order/init-order.test.js
+++ b/src/dagre/order/init-order.test.js
@@ -5,6 +5,7 @@ import { Graph } from '../../graphlib/graph.js';
 import { initOrder } from './init-order.js';
 
 describe('order/initOrder', function () {
+  /** @type {Graph} */
   var g;
 
   beforeEach(function () {

--- a/src/dagre/order/init-order.test.js
+++ b/src/dagre/order/init-order.test.js
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { Graph } from '../../graphlib/graph.js';
 import { initOrder } from './init-order.js';

--- a/src/dagre/order/resolve-conflicts.test.js
+++ b/src/dagre/order/resolve-conflicts.test.js
@@ -5,6 +5,7 @@ import { Graph } from '../../graphlib/graph.js';
 import { resolveConflicts } from './resolve-conflicts.js';
 
 describe('order/resolveConflicts', function () {
+  /** @type {Graph} */
   var cg;
 
   beforeEach(function () {

--- a/src/dagre/order/resolve-conflicts.test.js
+++ b/src/dagre/order/resolve-conflicts.test.js
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { Graph } from '../../graphlib/graph.js';
 import { resolveConflicts } from './resolve-conflicts.js';

--- a/src/dagre/order/sort-subgraph.test.js
+++ b/src/dagre/order/sort-subgraph.test.js
@@ -5,7 +5,10 @@ import { sortSubgraph } from './sort-subgraph.js';
 import { Graph } from '../../graphlib/graph.js';
 
 describe('order/sortSubgraph', function () {
-  var g, cg;
+  /** @type {Graph} */
+  var g;
+  /** @type {Graph} */
+  var cg;
 
   beforeEach(function () {
     g = new Graph({ compound: true })

--- a/src/dagre/order/sort-subgraph.test.js
+++ b/src/dagre/order/sort-subgraph.test.js
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { sortSubgraph } from './sort-subgraph.js';
 import { Graph } from '../../graphlib/graph.js';

--- a/src/dagre/parent-dummy-chains.test.js
+++ b/src/dagre/parent-dummy-chains.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { Graph } from '../graphlib/index.js';
 import { parentDummyChains } from './parent-dummy-chains.js';

--- a/src/dagre/position/bk.js
+++ b/src/dagre/position/bk.js
@@ -226,6 +226,7 @@ function horizontalCompaction(g, layering, root, align, reverseSep) {
   // sweeps. The first sweep places blocks with the smallest possible
   // coordinates. The second sweep removes unused space by moving blocks to the
   // greatest coordinates without violating separation.
+  /** @type {Record<import('../../graphlib/graph.js').NodeID, number>} */
   var xs = {},
     blockG = buildBlockGraph(g, layering, root, reverseSep),
     borderType = reverseSep ? 'borderLeft' : 'borderRight';

--- a/src/dagre/position/bk.test.js
+++ b/src/dagre/position/bk.test.js
@@ -17,6 +17,7 @@ import {
 import { Graph } from '../../graphlib/graph.js';
 
 describe('position/bk', function () {
+  /** @type {Graph} */
   var g;
 
   beforeEach(function () {

--- a/src/dagre/position/bk.test.js
+++ b/src/dagre/position/bk.test.js
@@ -150,6 +150,7 @@ describe('position/bk', function () {
 
   describe('hasConflict', function () {
     it('can test for a type-1 conflict regardless of edge orientation', function () {
+      /** @type {Parameters<typeof addConflict>[0]} */
       var conflicts = {};
       addConflict(conflicts, 'b', 'a');
       expect(hasConflict(conflicts, 'a', 'b')).to.be.true;
@@ -157,6 +158,7 @@ describe('position/bk', function () {
     });
 
     it('works for multiple conflicts with the same node', function () {
+      /** @type {Parameters<typeof addConflict>[0]} */
       var conflicts = {};
       addConflict(conflicts, 'a', 'b');
       addConflict(conflicts, 'a', 'c');
@@ -165,6 +167,7 @@ describe('position/bk', function () {
     });
 
     it('works for nodes named __proto__', function () {
+      /** @type {Parameters<typeof addConflict>[0]} */
       var conflicts = {};
       addConflict(conflicts, '__proto__', 'myAdminKey');
       expect(hasConflict(conflicts, '__proto__', 'myAdminKey')).to.be.true;
@@ -178,6 +181,7 @@ describe('position/bk', function () {
       g.setNode('b', { rank: 1, order: 0 });
 
       var layering = buildLayerMatrix(g);
+      /** @type {Parameters<typeof addConflict>[0]} */
       var conflicts = {};
 
       var result = verticalAlignment(g, layering, conflicts, g.predecessors.bind(g));
@@ -193,6 +197,7 @@ describe('position/bk', function () {
       g.setEdge('a', 'b');
 
       var layering = buildLayerMatrix(g);
+      /** @type {Parameters<typeof addConflict>[0]} */
       var conflicts = {};
 
       var result = verticalAlignment(g, layering, conflicts, g.predecessors.bind(g));
@@ -210,6 +215,7 @@ describe('position/bk', function () {
       g.setEdge('b', 'c');
 
       var layering = buildLayerMatrix(g);
+      /** @type {Parameters<typeof addConflict>[0]} */
       var conflicts = {};
 
       var result = verticalAlignment(g, layering, conflicts, g.predecessors.bind(g));
@@ -231,6 +237,7 @@ describe('position/bk', function () {
       g.setEdge('b', 'c');
 
       var layering = buildLayerMatrix(g);
+      /** @type {Parameters<typeof addConflict>[0]} */
       var conflicts = {};
 
       var result = verticalAlignment(g, layering, conflicts, g.predecessors.bind(g));
@@ -248,6 +255,7 @@ describe('position/bk', function () {
       g.setEdge('b', 'c');
 
       var layering = buildLayerMatrix(g);
+      /** @type {Parameters<typeof addConflict>[0]} */
       var conflicts = {};
 
       addConflict(conflicts, 'a', 'c');
@@ -269,6 +277,7 @@ describe('position/bk', function () {
       g.setEdge('b', 'd');
 
       var layering = buildLayerMatrix(g);
+      /** @type {Parameters<typeof addConflict>[0]} */
       var conflicts = {};
 
       var result = verticalAlignment(g, layering, conflicts, g.predecessors.bind(g));
@@ -290,6 +299,7 @@ describe('position/bk', function () {
       g.setEdge('c', 'd');
 
       var layering = buildLayerMatrix(g);
+      /** @type {Parameters<typeof addConflict>[0]} */
       var conflicts = {};
 
       var result = verticalAlignment(g, layering, conflicts, g.predecessors.bind(g));
@@ -308,6 +318,7 @@ describe('position/bk', function () {
       g.setPath(['a', 'c', 'd']);
 
       var layering = buildLayerMatrix(g);
+      /** @type {Parameters<typeof addConflict>[0]} */
       var conflicts = {};
 
       var result = verticalAlignment(g, layering, conflicts, g.predecessors.bind(g));

--- a/src/dagre/position/bk.test.js
+++ b/src/dagre/position/bk.test.js
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { buildLayerMatrix } from '../util.js';
 import {

--- a/src/dagre/position/index.test.js
+++ b/src/dagre/position/index.test.js
@@ -4,6 +4,7 @@ import { position } from './index.js';
 import { Graph } from '../../graphlib/index.js';
 
 describe('position', function () {
+  /** @type {Graph} */
   var g;
 
   beforeEach(function () {

--- a/src/dagre/position/index.test.js
+++ b/src/dagre/position/index.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { position } from './index.js';
 import { Graph } from '../../graphlib/index.js';

--- a/src/dagre/rank/index.test.js
+++ b/src/dagre/rank/index.test.js
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { rank } from './index.js';
 import { Graph } from '../../graphlib/graph.js';

--- a/src/dagre/rank/network-simplex.test.js
+++ b/src/dagre/rank/network-simplex.test.js
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { Graph } from '../../graphlib/graph.js';
 import { networkSimplex } from './network-simplex.js';
 import { longestPath } from './util.js';

--- a/src/dagre/rank/network-simplex.test.js
+++ b/src/dagre/rank/network-simplex.test.js
@@ -12,7 +12,14 @@ var exchangeEdges = networkSimplex.exchangeEdges;
 import { normalizeRanks } from '../util.js';
 
 describe('network simplex', function () {
-  var g, t, gansnerGraph, gansnerTree;
+  /** @type {Graph} */
+  var g;
+  /** @type {Graph} */
+  var t;
+  /** @type {Graph} */
+  var gansnerGraph;
+  /** @type {Graph} */
+  var gansnerTree;
 
   beforeEach(function () {
     g = new Graph({ multigraph: true })

--- a/src/dagre/rank/util.test.js
+++ b/src/dagre/rank/util.test.js
@@ -6,6 +6,7 @@ import { longestPath } from './util.js';
 
 describe('rank/util', function () {
   describe('longestPath', function () {
+    /** @type {Graph} */
     var g;
 
     beforeEach(function () {

--- a/src/dagre/rank/util.test.js
+++ b/src/dagre/rank/util.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { Graph } from '../../graphlib/graph.js';
 import { normalizeRanks } from '../util.js';

--- a/src/dagre/util.test.js
+++ b/src/dagre/util.test.js
@@ -1,5 +1,5 @@
 import * as _ from 'lodash-es';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { Graph } from '../graphlib/index.js';
 import * as util from './util.js';
 

--- a/src/dagre/util.test.js
+++ b/src/dagre/util.test.js
@@ -5,6 +5,7 @@ import * as util from './util.js';
 
 describe('util', function () {
   describe('simplify', function () {
+    /** @type {Graph} */
     var g;
 
     beforeEach(function () {

--- a/src/graphlib/data/priority-queue.test.js
+++ b/src/graphlib/data/priority-queue.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { PriorityQueue } from './priority-queue.js';
 

--- a/src/graphlib/graph.js
+++ b/src/graphlib/graph.js
@@ -4,6 +4,31 @@ var DEFAULT_EDGE_NAME = '\x00';
 var GRAPH_NODE = '\x00';
 var EDGE_KEY_DELIM = '\x01';
 
+/**
+ * @typedef {string} NodeID ID of a node.
+ */
+
+/**
+ * @typedef {`${string}${typeof EDGE_KEY_DELIM}${string}${typeof EDGE_KEY_DELIM}${string}`} EdgeID ID of an edge.
+ */
+
+/**
+ * @typedef {object} EdgeObj
+ * @property {NodeID} v Source node ID.
+ * @property {NodeID} w Target node ID.
+ * @property {string | number} [name] Name of the edge. Needed to uniquely identify
+ * multiple edges between the same pair of nodes in a multigraph.
+ */
+
+/**
+ * @template {unknown} T
+ * @typedef {T[] | Record<any, T>} Collection
+ * Lodash object that can be iterated over with `_.each`.
+ *
+ * Beware, objects with `.length` are treated as arrays, see
+ * https://lodash.com/docs/4.17.15#forEach
+ */
+
 // Implementation notes:
 //
 //  * Node id query functions should return string ids for the nodes
@@ -23,58 +48,138 @@ var EDGE_KEY_DELIM = '\x01';
 //    reference edges. This is because we need a performant way to look these
 //    edges up and, object properties, which have string keys, are the closest
 //    we're going to get to a performant hashtable in JavaScript.
+
+/**
+ * @template [GraphLabel=any] - Label of the graph.
+ * @template [NodeLabel=any] - Label of a node.
+ * Even though this is a "label", this could be any type that the user requires
+ * (and may need to be an object for some layout/ranking algorithms in dagre).
+ * @template [EdgeLabel=any] - Label of an edge.
+ * Even though this is a "label", this could be any type that the user requires,
+ * (and may need to be a object for ranking in dagre).
+ */
 export class Graph {
+  /**
+   * @param {object} [opts] - Graph options.
+   * @param {boolean | undefined} [opts.directed] - If `false`, creates an undirected graph.
+   * @param {boolean | undefined} [opts.multigraph] - If `true`, allows multiple, named-edges between nodes.
+   * @param {boolean | undefined} [opts.compound] - If `true`, allows nodes to be parents of other nodes.
+   */
   constructor(opts = {}) {
+    /**
+     * @type {boolean}
+     * @private
+     */
     this._isDirected = Object.prototype.hasOwnProperty.call(opts, 'directed')
       ? opts.directed
       : true;
+    /**
+     * @type {boolean}
+     * @private
+     */
     this._isMultigraph = Object.prototype.hasOwnProperty.call(opts, 'multigraph')
       ? opts.multigraph
       : false;
+    /**
+     * @type {boolean}
+     * @private
+     */
     this._isCompound = Object.prototype.hasOwnProperty.call(opts, 'compound')
       ? opts.compound
       : false;
 
-    // Label for the graph itself
+    /**
+     * @type {GraphLabel | undefined}
+     * Label for the graph itself
+     */
     this._label = undefined;
 
-    // Defaults to be set when creating a new node
+    /**
+     * Default label to be set when creating a new node.
+     *
+     * @private
+     * @type {(v: NodeID | number) => NodeLabel}
+     */
     this._defaultNodeLabelFn = _.constant(undefined);
 
-    // Defaults to be set when creating a new edge
+    /**
+     * Default label to be set when creating a new edge
+     *
+     * @private
+     * @type {(v: NodeID, w: NodeID, name: string | undefined) => EdgeLabel}
+     */
     this._defaultEdgeLabelFn = _.constant(undefined);
 
-    // v -> label
+    /**
+     * @type {Record<NodeID, NodeLabel>}
+     * @private
+     *
+     * v -> label
+     */
     this._nodes = {};
 
     if (this._isCompound) {
-      // v -> parent
+      /**
+       * @type {Record<NodeID, NodeID>}
+       * @private
+       * v -> parent
+       */
       this._parent = {};
 
-      // v -> children
+      /**
+       * @type {Record<NodeID, Record<NodeID, true>>}
+       * @private
+       * v -> children
+       */
       this._children = {};
       this._children[GRAPH_NODE] = {};
     }
 
-    // v -> edgeObj
+    /**
+     * @type {Record<NodeID, Record<EdgeID, EdgeObj>>}
+     * @private
+     * v -> edgeObj
+     */
     this._in = {};
 
-    // u -> v -> Number
+    /**
+     * @type {Record<NodeID, Record<NodeID, number>>}
+     * @private
+     * u -> v -> Number
+     */
     this._preds = {};
 
-    // v -> edgeObj
+    /**
+     * @type {Record<NodeID, Record<EdgeID, EdgeObj>>}
+     * @private
+     * v -> edgeObj
+     */
     this._out = {};
 
-    // v -> w -> Number
+    /**
+     * @type {Record<NodeID, Record<NodeID, number>>}
+     * @private
+     * v -> w -> Number
+     */
     this._sucs = {};
 
-    // e -> edgeObj
+    /**
+     * @type {Record<EdgeID, EdgeObj>}
+     * @private
+     * e -> edgeObj
+     */
     this._edgeObjs = {};
 
-    // e -> label
+    /**
+     * @type {Record<EdgeID, EdgeLabel>}
+     * @private
+     * e -> label
+     */
     this._edgeLabels = {};
   }
+
   /* === Graph functions ========= */
+
   isDirected() {
     return this._isDirected;
   }
@@ -84,14 +189,28 @@ export class Graph {
   isCompound() {
     return this._isCompound;
   }
+
+  /**
+   * @param {GraphLabel} label - Label for the graph.
+   * @returns {this}
+   */
   setGraph(label) {
     this._label = label;
     return this;
   }
+
+  /**
+   * @returns {GraphLabel | undefined} Label for the graph, or `undefined` if none has been set.
+   */
   graph() {
     return this._label;
   }
   /* === Node functions ========== */
+
+  /**
+   * @param {typeof this._defaultNodeLabelFn | NodeLabel} newDefault - Function that creates the default label for new nodes, or a constant label.
+   * @returns {this}
+   */
   setDefaultNodeLabel(newDefault) {
     if (!_.isFunction(newDefault)) {
       newDefault = _.constant(newDefault);
@@ -102,21 +221,39 @@ export class Graph {
   nodeCount() {
     return this._nodeCount;
   }
+
+  /**
+   * @returns {NodeID[]} Array of all node ids.
+   */
   nodes() {
     return _.keys(this._nodes);
   }
+  /**
+   * @returns {NodeID[]} Array of source node ids (nodes with no in-edges).
+   */
   sources() {
     var self = this;
     return _.filter(this.nodes(), function (v) {
       return _.isEmpty(self._in[v]);
     });
   }
+  /**
+   * @returns {NodeID[]} Array of sink node ids (nodes with no out-edges).
+   */
   sinks() {
     var self = this;
     return _.filter(this.nodes(), function (v) {
       return _.isEmpty(self._out[v]);
     });
   }
+
+  /**
+   * Set/create multiple nodes.
+   *
+   * @param {Collection<NodeID | number>} vs - List of node IDs to create/set.
+   * @param {NodeLabel} [value] - If set, update all nodes with this value.
+   * @returns {this}
+   */
   setNodes(vs, value) {
     var args = arguments;
     var self = this;
@@ -129,6 +266,13 @@ export class Graph {
     });
     return this;
   }
+
+  /**
+   * @param {NodeID | number} v - ID of the node to create/set.
+   * @param {NodeLabel} [value] - If not set, leave the value as-is if the node is already created.
+   * Otherwise, use the default value set by {@link setDefaultNodeLabel}.
+   * @returns {this}
+   */
   setNode(v, value) {
     if (Object.prototype.hasOwnProperty.call(this._nodes, v)) {
       if (arguments.length > 1) {
@@ -137,7 +281,6 @@ export class Graph {
       return this;
     }
 
-    // @ts-expect-error
     this._nodes[v] = arguments.length > 1 ? value : this._defaultNodeLabelFn(v);
     if (this._isCompound) {
       this._parent[v] = GRAPH_NODE;
@@ -151,12 +294,29 @@ export class Graph {
     ++this._nodeCount;
     return this;
   }
+
+  /**
+   * Gets the label for the given node ID, or `undefined` if it does not exist.
+   *
+   * @param {NodeID | number} v - Node ID.
+   * @returns {NodeLabel | undefined}
+   */
   node(v) {
     return this._nodes[v];
   }
+
+  /**
+   * @param {NodeID | number} v - Node ID.
+   * @returns {boolean} Returns `true` if the given node ID exists, else `false`.
+   */
   hasNode(v) {
     return Object.prototype.hasOwnProperty.call(this._nodes, v);
   }
+
+  /**
+   * @param {NodeID | number} v - Node ID to remove.
+   * @returns {this}
+   */
   removeNode(v) {
     if (Object.prototype.hasOwnProperty.call(this._nodes, v)) {
       var removeEdge = (e) => this.removeEdge(this._edgeObjs[e]);
@@ -179,6 +339,16 @@ export class Graph {
     }
     return this;
   }
+
+  /**
+   * Set or remove the parent of a node.
+   *
+   * @param {NodeID | number} v - Node ID to set the parent for.
+   * @param {NodeID | number} [parent] - Parent node ID. If not specified, removes the parent.
+   * @returns {this}
+   * @throws if the graph is not compound.
+   * @throws if setting the parent would create a cycle.
+   */
   setParent(v, parent) {
     if (!this._isCompound) {
       throw new Error('Cannot set parent in a non-compound graph');
@@ -200,13 +370,27 @@ export class Graph {
 
     this.setNode(v);
     this._removeFromParentsChildList(v);
+    // @ts-expect-error -- We coerced parent to a string above
     this._parent[v] = parent;
     this._children[parent][v] = true;
     return this;
   }
+
+  /**
+   * @private
+   * @param {NodeID | number} v - Node ID.
+   */
   _removeFromParentsChildList(v) {
     delete this._children[this._parent[v]][v];
   }
+
+  /**
+   * Gets the parent of the specified node.
+   *
+   * @param {NodeID | number} v - Node ID.
+   * @returns {NodeID | undefined} The parent node ID, or `undefined` if there is no parent
+   * (i.e. node does not exist, it's a root node, or the graph is not compound).
+   */
   parent(v) {
     if (this._isCompound) {
       var parent = this._parent[v];
@@ -215,6 +399,11 @@ export class Graph {
       }
     }
   }
+
+  /**
+   * @param {NodeID | number} [v] - Node ID. If not specified, gets the children of the root.
+   * @returns {NodeID[] | undefined} Array of child node IDs, or `undefined` if the node does not exist.
+   */
   children(v) {
     if (_.isUndefined(v)) {
       v = GRAPH_NODE;
@@ -231,24 +420,44 @@ export class Graph {
       return [];
     }
   }
+
+  /**
+   * @param {NodeID | number} v - Node ID.
+   * @returns {NodeID[] | undefined} Array of predecessor (nodes that have an edge to this node) node IDs, or `undefined` if the node does not exist.
+   */
   predecessors(v) {
     var predsV = this._preds[v];
     if (predsV) {
       return _.keys(predsV);
     }
   }
+
+  /**
+   * @param {NodeID | number} v - Node ID.
+   * @returns {NodeID[] | undefined} Array of successor (nodes that this node has an edge to) node IDs, or `undefined` if the node does not exist.
+   */
   successors(v) {
     var sucsV = this._sucs[v];
     if (sucsV) {
       return _.keys(sucsV);
     }
   }
+
+  /**
+   * @param {NodeID | number} v - Node ID.
+   * @returns {NodeID[] | undefined} Array of neighbor (nodes that share one of the same predecessors) node IDs, or `undefined` if the node does not exist.
+   */
   neighbors(v) {
     var preds = this.predecessors(v);
     if (preds) {
       return _.union(preds, this.successors(v));
     }
   }
+
+  /**
+   * @param {NodeID | number} v - Node ID.
+   * @returns {boolean} True if the node is a leaf (has no successors), false otherwise.
+   */
   isLeaf(v) {
     var neighbors;
     if (this.isDirected()) {
@@ -258,7 +467,15 @@ export class Graph {
     }
     return neighbors.length === 0;
   }
+
+  /**
+   * @param {(v: NodeID) => boolean} filter - Function that returns `true` for nodes to keep.
+   * @returns {Graph<GraphLabel, NodeLabel, EdgeLabel>} A new graph containing only the nodes for which `filter` returns `true`.
+   */
   filterNodes(filter) {
+    /**
+     * @type {Graph<GraphLabel, NodeLabel, EdgeLabel>}
+     */
     // @ts-expect-error
     var copy = new this.constructor({
       directed: this._isDirected,
@@ -276,7 +493,6 @@ export class Graph {
     });
 
     _.each(this._edgeObjs, function (e) {
-      // @ts-expect-error
       if (copy.hasNode(e.v) && copy.hasNode(e.w)) {
         copy.setEdge(e, self.edge(e));
       }
@@ -303,7 +519,13 @@ export class Graph {
 
     return copy;
   }
+
   /* === Edge functions ========== */
+
+  /**
+   * @param {typeof this._defaultEdgeLabelFn | EdgeLabel} newDefault - Function that creates the default label for new edges, or a constant label.
+   * @returns {this}
+   */
   setDefaultEdgeLabel(newDefault) {
     if (!_.isFunction(newDefault)) {
       newDefault = _.constant(newDefault);
@@ -317,6 +539,13 @@ export class Graph {
   edges() {
     return _.values(this._edgeObjs);
   }
+
+  /**
+   * Creates edges between the given Node IDs.
+   * @param {Collection<NodeID>} vs - List of node IDs to create edges between.
+   * @param {EdgeLabel} [value] - If set, update all edges with this value.
+   * @returns {this}
+   */
   setPath(vs, value) {
     var self = this;
     var args = arguments;
@@ -330,9 +559,26 @@ export class Graph {
     });
     return this;
   }
-  /*
-   * setEdge(v, w, [value, [name]])
-   * setEdge({ v, w, [name] }, [value])
+
+  /**
+   * Create or set the given edge.
+   *
+   * @overload
+   * @param {EdgeObj} arg0 - Edge object.
+   * @param {EdgeLabel} [value] - If set, update the edge with this value.
+   * If not set and the edge is being created, calls the function set by {@link setDefaultEdgeLabel}.
+   * @returns {this}
+   */
+  /**
+   * Create or set the given edge.
+   *
+   * @overload
+   * @param {NodeID | number} v - Source node ID. Number values will be coerced to strings.
+   * @param {NodeID | number} w - Target node ID. Number values will be coerced to strings.
+   * @param {EdgeLabel} [value] - If set, update the edge with this value.
+   * If not set and the edge is being created, calls the function set by {@link setDefaultEdgeLabel}.
+   * @param {string | number} [name] - Edge name.
+   * @returns {this}
    */
   setEdge() {
     var v, w, name, value;
@@ -380,7 +626,6 @@ export class Graph {
     this.setNode(v);
     this.setNode(w);
 
-    // @ts-expect-error
     this._edgeLabels[e] = valueSpecified ? value : this._defaultEdgeLabelFn(v, w, name);
 
     var edgeObj = edgeArgsToObj(this._isDirected, v, w, name);
@@ -397,6 +642,21 @@ export class Graph {
     this._edgeCount++;
     return this;
   }
+
+  /**
+   * Get the label for the given edge.
+   * @overload
+   * @param {EdgeObj} v - Edge object.
+   * @returns {EdgeLabel | undefined} The label, or `undefined` if the edge does not exist.
+   */
+  /**
+   * Get the label for the given edge.
+   * @overload
+   * @param {NodeID | number} v - Source node ID.
+   * @param {NodeID | number} w - Target node ID.
+   * @param {string | number} [name] - Edge name.
+   * @returns {EdgeLabel | undefined} The label, or `undefined` if the edge does not exist.
+   */
   edge(v, w, name) {
     var e =
       arguments.length === 1
@@ -404,6 +664,19 @@ export class Graph {
         : edgeArgsToId(this._isDirected, v, w, name);
     return this._edgeLabels[e];
   }
+
+  /**
+   * @overload
+   * @param {EdgeObj} v - Edge object.
+   * @returns {boolean} `true` if the edge exists, else `false`.
+   */
+  /**
+   * @overload
+   * @param {NodeID | number} v - Source node ID.
+   * @param {NodeID | number} w - Target node ID.
+   * @param {string | number} [name] - Edge name.
+   * @returns {boolean} `true` if the edge exists, else `false`.
+   */
   hasEdge(v, w, name) {
     var e =
       arguments.length === 1
@@ -411,6 +684,19 @@ export class Graph {
         : edgeArgsToId(this._isDirected, v, w, name);
     return Object.prototype.hasOwnProperty.call(this._edgeLabels, e);
   }
+
+  /**
+   * @overload
+   * @param {EdgeObj} v - Edge object.
+   * @returns {this}
+   */
+  /**
+   * @overload
+   * @param {NodeID | number} v - Source node ID.
+   * @param {NodeID | number} w - Target node ID.
+   * @param {string | number} [name] - Edge name.
+   * @returns {this}
+   */
   removeEdge(v, w, name) {
     var e =
       arguments.length === 1
@@ -430,6 +716,12 @@ export class Graph {
     }
     return this;
   }
+
+  /**
+   * @param {NodeID | number} v - Target node ID.
+   * @param {NodeID | number} [u] - If set, filters edges to only those between nodes `v` and `u`.
+   * @returns {EdgeObj[] | undefined} Array of incoming edges to node `v`, or `undefined` if node `v` does not exist.
+   */
   inEdges(v, u) {
     var inV = this._in[v];
     if (inV) {
@@ -442,6 +734,12 @@ export class Graph {
       });
     }
   }
+
+  /**
+   * @param {NodeID | number} v - Target node ID.
+   * @param {NodeID | number} [w] - If set, filters edges to only those between nodes `v` and `w`.
+   * @returns {EdgeObj[] | undefined} Array of outgoing edges to node `v`, or `undefined` if node `v` does not exist.
+   */
   outEdges(v, w) {
     var outV = this._out[v];
     if (outV) {
@@ -454,6 +752,13 @@ export class Graph {
       });
     }
   }
+
+  /**
+   * List of all edges to/from node `v`.
+   * @param {NodeID | number} v - Target Node ID.
+   * @param {NodeID | number} [w] - If set, filters edges to only those between nodes `v` and `w`.
+   * @returns {EdgeObj[] | undefined} Array of edges to/from node `v`, or `undefined` if node `v` does not exist.
+   */
   nodeEdges(v, w) {
     var inEdges = this.inEdges(v, w);
     if (inEdges) {
@@ -468,6 +773,10 @@ Graph.prototype._nodeCount = 0;
 /* Number of edges in the graph. Should only be changed by the implementation. */
 Graph.prototype._edgeCount = 0;
 
+/**
+ * @param {Record<NodeID, number>} map - Object mapping node IDs to counts.
+ * @param {NodeID | number} k - Node ID.
+ */
 function incrementOrInitEntry(map, k) {
   if (map[k]) {
     map[k]++;
@@ -476,12 +785,23 @@ function incrementOrInitEntry(map, k) {
   }
 }
 
+/**
+ * @param {Record<NodeID, number>} map - Object mapping node IDs to counts.
+ * @param {NodeID | number} k - Node ID.
+ */
 function decrementOrRemoveEntry(map, k) {
   if (!--map[k]) {
     delete map[k];
   }
 }
 
+/**
+ * @param {boolean} isDirected - If `false`, sorts v and w to ensure a consistent ID.
+ * @param {EdgeObj['v'] | number} v_ - Source node ID.
+ * @param {EdgeObj['w'] | number} w_ - Target node ID.
+ * @param {EdgeObj['name']} [name] - Edge name (for multiple edges between the same nodes).
+ * @returns {EdgeID} Unique ID for the edge.
+ */
 function edgeArgsToId(isDirected, v_, w_, name) {
   var v = '' + v_;
   var w = '' + w_;
@@ -493,6 +813,13 @@ function edgeArgsToId(isDirected, v_, w_, name) {
   return v + EDGE_KEY_DELIM + w + EDGE_KEY_DELIM + (_.isUndefined(name) ? DEFAULT_EDGE_NAME : name);
 }
 
+/**
+ * @param {boolean} isDirected - If `false`, sorts v and w to ensure a consistent ID.
+ * @param {EdgeObj['v'] | number} v_ - Source node ID.
+ * @param {EdgeObj['w'] | number} w_ - Target node ID.
+ * @param {EdgeObj['name']} [name] - Edge name (for multiple edges between the same nodes).
+ * @returns {EdgeObj}
+ */
 function edgeArgsToObj(isDirected, v_, w_, name) {
   var v = '' + v_;
   var w = '' + w_;
@@ -508,6 +835,11 @@ function edgeArgsToObj(isDirected, v_, w_, name) {
   return edgeObj;
 }
 
+/**
+ * @param {boolean} isDirected - If `false`, sorts v and w to ensure a consistent ID.
+ * @param {EdgeObj} edgeObj - Edge object.
+ * @returns {EdgeID} Unique ID for the edge.
+ */
 function edgeObjToId(isDirected, edgeObj) {
   return edgeArgsToId(isDirected, edgeObj.v, edgeObj.w, edgeObj.name);
 }

--- a/src/graphlib/graph.js
+++ b/src/graphlib/graph.js
@@ -10,12 +10,13 @@ var EDGE_KEY_DELIM = '\x01';
 
 /**
  * @typedef {`${string}${typeof EDGE_KEY_DELIM}${string}${typeof EDGE_KEY_DELIM}${string}`} EdgeID ID of an edge.
+ * @internal - All public APIs use {@link EdgeObj} instead to refer to edges.
  */
 
 /**
  * @typedef {object} EdgeObj
- * @property {NodeID} v Source node ID.
- * @property {NodeID} w Target node ID.
+ * @property {NodeID} v the id of the source or tail node of an edge
+ * @property {NodeID} w the id of the target or head node of an edge
  * @property {string | number} [name] Name of the edge. Needed to uniquely identify
  * multiple edges between the same pair of nodes in a multigraph.
  */
@@ -50,6 +51,142 @@ var EDGE_KEY_DELIM = '\x01';
 //    we're going to get to a performant hashtable in JavaScript.
 
 /**
+ * @typedef {object} GraphOptions
+ * @property {boolean | undefined} [directed] - set to `true` to get a
+ * directed graph and `false` to get an undirected graph.
+ * An undirected graph does not treat the order of nodes in an edge as
+ * significant.
+ * In other words, `g.edge("a", "b") === g.edge("b", "a")` for
+ * an undirected graph.
+ * Default: `true`
+ * @property {boolean | undefined} [multigraph] - set to `true` to allow a
+ * graph to have multiple edges between the same pair of nodes.
+ * Default: `false`.
+ * @property {boolean | undefined} [compound] - set to `true` to allow a
+ * graph to have compound nodes - nodes which can be the parent of other
+ * nodes.
+ * Default: `false`.
+ */
+
+/**
+ * Graphlib has a single graph type: {@link Graph}. To create a new instance:
+ *
+ * ```js
+ * var g = new Graph();
+ * ```
+ *
+ * By default this will create a directed graph that does not allow multi-edges
+ * or compound nodes.
+ * The following options can be used when constructing a new graph:
+ *
+ * * {@link GraphOptions#directed}: set to `true` to get a directed graph and `false` to get an
+ *   undirected graph.
+ *   An undirected graph does not treat the order of nodes in an edge as
+ *   significant. In other words,
+ *   `g.edge("a", "b") === g.edge("b", "a")` for an undirected graph.
+ *   Default: `true`.
+ * * {@link GraphOptions#multigraph}: set to `true` to allow a graph to have multiple edges
+ *   between the same pair of nodes. Default: `false`.
+ * * {@link GraphOptions#compound}: set to `true` to allow a graph to have compound nodes -
+ *   nodes which can be the parent of other nodes. Default: `false`.
+ *
+ * To set the options, pass in an options object to the `Graph` constructor.
+ * For example, to create a directed compound multigraph:
+ *
+ * ```js
+ * var g = new Graph({ directed: true, compound: true, multigraph: true });
+ * ```
+ *
+ * ### Node and Edge Representation
+ *
+ * In graphlib, a node is represented by a user-supplied String id.
+ * All node related functions use this String id as a way to uniquely identify
+ * the node. Here is an example of interacting with nodes:
+ *
+ * ```js
+ * var g = new Graph();
+ * g.setNode("my-id", "my-label");
+ * g.node("my-id"); // returns "my-label"
+ * ```
+ *
+ * Edges in graphlib are identified by the nodes they connect. For example:
+ *
+ * ```js
+ * var g = new Graph();
+ * g.setEdge("source", "target", "my-label");
+ * g.edge("source", "target"); // returns "my-label"
+ * ```
+ *
+ * However, we need a way to uniquely identify an edge in a single object for
+ * various edge queries (e.g. {@link Graph#outEdges}).
+ * We use {@link EdgeObj}s for this purpose.
+ * They consist of the following properties:
+ *
+ * * {@link EdgeObj#v}: the id of the source or tail node of an edge
+ * * {@link EdgeObj#w}: the id of the target or head node of an edge
+ * * {@link EdgeObj#name} (optional): the name that uniquely identifies a multiedge.
+ *
+ * Any edge function that takes an edge id will also work with an {@link EdgeObj}. For example:
+ *
+ * ```js
+ * var g = new Graph();
+ * g.setEdge("source", "target", "my-label");
+ * g.edge({ v: "source", w: "target" }); // returns "my-label"
+ * ```
+ *
+ * ### Multigraphs
+ *
+ * A [multigraph](https://en.wikipedia.org/wiki/Multigraph) is a graph that can
+ * have more than one edge between the same pair of nodes.
+ * By default graphlib graphs are not multigraphs, but a multigraph can be
+ * constructed by setting the {@link GraphOptions#multigraph} property to true:
+ *
+ * ```js
+ * var g = new Graph({ multigraph: true });
+ * ```
+ *
+ * With multiple edges between two nodes we need some way to uniquely identify
+ * each edge. We call this the {@link EdgeObj#name} property.
+ * Here's an example of creating a couple of edges between the same nodes:
+ *
+ * ```js
+ * var g = new Graph({ multigraph: true });
+ * g.setEdge("a", "b", "edge1-label", "edge1");
+ * g.setEdge("a", "b", "edge2-label", "edge2");
+ * g.edge("a", "b", "edge1"); // returns "edge1-label"
+ * g.edge("a", "b", "edge2"); // returns "edge2-label"
+ * g.edges(); // returns [{ v: "a", w: "b", name: "edge1" },
+ *            //          { v: "a", w: "b", name: "edge2" }]
+ * ```
+ *
+ * A multigraph still allows an edge with no name to be created:
+ *
+ * ```js
+ * var g = new Graph({ multigraph: true });
+ * g.setEdge("a", "b", "my-label");
+ * g.edge({ v: "a", w: "b" }); // returns "my-label"
+ * ```
+ *
+ * ### Compound Graphs
+ *
+ * A compound graph is one where a node can be the parent of other nodes.
+ * The child nodes form a "subgraph".
+ * Here's an example of constructing and interacting with a compound graph:
+ *
+ * ```js
+ * var g = new Graph({ compound: true });
+ * g.setParent("a", "parent");
+ * g.setParent("b", "parent");
+ * g.parent("a");      // returns "parent"
+ * g.parent("b");      // returns "parent"
+ * g.parent("parent"); // returns undefined
+ * ```
+ *
+ * ### Default Labels
+ *
+ * When a node or edge is created without a label, a default label can be assigned.
+ * See {@link setDefaultNodeLabel} and {@link setDefaultEdgeLabel}.
+ *
  * @template [GraphLabel=any] - Label of the graph.
  * @template [NodeLabel=any] - Label of a node.
  * Even though this is a "label", this could be any type that the user requires
@@ -60,10 +197,7 @@ var EDGE_KEY_DELIM = '\x01';
  */
 export class Graph {
   /**
-   * @param {object} [opts] - Graph options.
-   * @param {boolean | undefined} [opts.directed] - If `false`, creates an undirected graph.
-   * @param {boolean | undefined} [opts.multigraph] - If `true`, allows multiple, named-edges between nodes.
-   * @param {boolean | undefined} [opts.compound] - If `true`, allows nodes to be parents of other nodes.
+   * @param {GraphOptions} [opts] - Graph options.
    */
   constructor(opts = {}) {
     /**
@@ -180,17 +314,47 @@ export class Graph {
 
   /* === Graph functions ========= */
 
+  /**
+   *
+   * @returns {boolean} `true` if the graph is [directed](https://en.wikipedia.org/wiki/Directed_graph).
+   * A directed graph treats the order of nodes in an edge as significant whereas an
+   * [undirected](https://en.wikipedia.org/wiki/Graph_(mathematics)#Undirected_graph)
+   * graph does not.
+   * This example demonstrates the difference:
+   *
+   * @example
+   *
+   * ```js
+   * var directed = new Graph({ directed: true });
+   * directed.setEdge("a", "b", "my-label");
+   * directed.edge("a", "b"); // returns "my-label"
+   * directed.edge("b", "a"); // returns undefined
+   *
+   * var undirected = new Graph({ directed: false });
+   * undirected.setEdge("a", "b", "my-label");
+   * undirected.edge("a", "b"); // returns "my-label"
+   * undirected.edge("b", "a"); // returns "my-label"
+   * ```
+   */
   isDirected() {
     return this._isDirected;
   }
+  /**
+   * @returns {boolean} `true` if the graph is a multigraph.
+   */
   isMultigraph() {
     return this._isMultigraph;
   }
+  /**
+   * @returns {boolean} `true` if the graph is compound.
+   */
   isCompound() {
     return this._isCompound;
   }
 
   /**
+   * Sets the label for the graph to `label`.
+   *
    * @param {GraphLabel} label - Label for the graph.
    * @returns {this}
    */
@@ -200,7 +364,17 @@ export class Graph {
   }
 
   /**
-   * @returns {GraphLabel | undefined} Label for the graph, or `undefined` if none has been set.
+   * @returns {GraphLabel | undefined} the currently assigned label for the graph.
+   * If no label has been assigned, returns `undefined`.
+   *
+   * @example
+   *
+   * ```js
+   * var g = new Graph();
+   * g.graph(); // returns undefined
+   * g.setGraph("graph-label");
+   *  g.graph(); // returns "graph-label"
+   * ```
    */
   graph() {
     return this._label;
@@ -208,7 +382,12 @@ export class Graph {
   /* === Node functions ========== */
 
   /**
-   * @param {typeof this._defaultNodeLabelFn | NodeLabel} newDefault - Function that creates the default label for new nodes, or a constant label.
+   * Sets a new default value that is assigned to nodes that are created without
+   * a label.
+   *
+   * @param {typeof this._defaultNodeLabelFn | NodeLabel} newDefault - If a function,
+   * it is called with the id of the node being created.
+   * Otherwise, it is assigned as the label directly.
    * @returns {this}
    */
   setDefaultNodeLabel(newDefault) {
@@ -218,18 +397,27 @@ export class Graph {
     this._defaultNodeLabelFn = newDefault;
     return this;
   }
+
+  /**
+   * @returns {number} the number of nodes in the graph.
+   */
   nodeCount() {
     return this._nodeCount;
   }
 
   /**
-   * @returns {NodeID[]} Array of all node ids.
+   * @returns {NodeID[]} the ids of the nodes in the graph.
+   *
+   * @remarks
+   * Use {@link node()} to get the label for each node.
+   * Takes `O(|V|)` time.
    */
   nodes() {
     return _.keys(this._nodes);
   }
   /**
-   * @returns {NodeID[]} Array of source node ids (nodes with no in-edges).
+   * @returns {NodeID[]} those nodes in the graph that have no in-edges.
+   * @remarks Takes `O(|V|)` time.
    */
   sources() {
     var self = this;
@@ -238,7 +426,8 @@ export class Graph {
     });
   }
   /**
-   * @returns {NodeID[]} Array of sink node ids (nodes with no out-edges).
+   * @returns {NodeID[]} those nodes in the graph that have no out-edges.
+   * @remarks Takes `O(|V|)` time.
    */
   sinks() {
     var self = this;
@@ -248,11 +437,12 @@ export class Graph {
   }
 
   /**
-   * Set/create multiple nodes.
+   * Invokes setNode method for each node in `vs` list.
    *
    * @param {Collection<NodeID | number>} vs - List of node IDs to create/set.
    * @param {NodeLabel} [value] - If set, update all nodes with this value.
    * @returns {this}
+   * @remarks Complexity: O(|names|).
    */
   setNodes(vs, value) {
     var args = arguments;
@@ -268,10 +458,14 @@ export class Graph {
   }
 
   /**
+   * Creates or updates the value for the node `v` in the graph.
+   *
    * @param {NodeID | number} v - ID of the node to create/set.
-   * @param {NodeLabel} [value] - If not set, leave the value as-is if the node is already created.
-   * Otherwise, use the default value set by {@link setDefaultNodeLabel}.
-   * @returns {this}
+   * @param {NodeLabel} [value] - If supplied, it is set as the value for the node.
+   * If not supplied and the node was created by this call then
+   * {@link setDefaultNodeLabel} will be used to set the node's value.
+   * @returns {this} the graph, allowing this to be chained with other functions.
+   * @remarks Takes `O(1)` time.
    */
   setNode(v, value) {
     if (Object.prototype.hasOwnProperty.call(this._nodes, v)) {
@@ -296,26 +490,38 @@ export class Graph {
   }
 
   /**
-   * Gets the label for the given node ID, or `undefined` if it does not exist.
+   * Gets the label of node with specified name.
    *
    * @param {NodeID | number} v - Node ID.
-   * @returns {NodeLabel | undefined}
+   * @returns {NodeLabel | undefined} the label assigned to the node with the id `v`
+   * if it is in the graph.
+   * Otherwise returns `undefined`.
+   * @remarks Takes `O(1)` time.
    */
   node(v) {
     return this._nodes[v];
   }
 
   /**
+   * Detects whether graph has a node with specified name or not.
+   *
    * @param {NodeID | number} v - Node ID.
-   * @returns {boolean} Returns `true` if the given node ID exists, else `false`.
+   * @returns {boolean} Returns `true` the graph has a node with the id.
+   * @remarks Takes `O(1)` time.
    */
   hasNode(v) {
     return Object.prototype.hasOwnProperty.call(this._nodes, v);
   }
 
   /**
+   * Remove the node with the id `v` in the graph or do nothing if the node is
+   * not in the graph.
+   *
+   * If the node was removed this function also removes any incident edges.
+   *
    * @param {NodeID | number} v - Node ID to remove.
-   * @returns {this}
+   * @returns {this} the graph, allowing this to be chained with other functions.
+   * @remarks Takes `O(|E|)` time.
    */
   removeNode(v) {
     if (Object.prototype.hasOwnProperty.call(this._nodes, v)) {
@@ -341,13 +547,15 @@ export class Graph {
   }
 
   /**
-   * Set or remove the parent of a node.
+   * Sets the parent for `v` to `parent` if it is defined or removes the parent
+   * for `v` if `parent` is undefined.
    *
    * @param {NodeID | number} v - Node ID to set the parent for.
-   * @param {NodeID | number} [parent] - Parent node ID. If not specified, removes the parent.
-   * @returns {this}
+   * @param {NodeID | number} [parent] - Parent node ID. If not defined, removes the parent.
+   * @returns {this} the graph, allowing this to be chained with other functions.
    * @throws if the graph is not compound.
    * @throws if setting the parent would create a cycle.
+   * @remarks Takes `O(1)` time.
    */
   setParent(v, parent) {
     if (!this._isCompound) {
@@ -385,11 +593,14 @@ export class Graph {
   }
 
   /**
-   * Gets the parent of the specified node.
+   * Get parent node for node `v`.
    *
    * @param {NodeID | number} v - Node ID.
-   * @returns {NodeID | undefined} The parent node ID, or `undefined` if there is no parent
-   * (i.e. node does not exist, it's a root node, or the graph is not compound).
+   * @returns {NodeID | undefined} the node that is a parent of node `v`
+   * or `undefined` if node `v` does not have a parent or is not a member of
+   * the graph.
+   * Always returns `undefined` for graphs that are not compound.
+   * @remarks Takes `O(1)` time.
    */
   parent(v) {
     if (this._isCompound) {
@@ -401,8 +612,14 @@ export class Graph {
   }
 
   /**
-   * @param {NodeID | number} [v] - Node ID. If not specified, gets the children of the root.
-   * @returns {NodeID[] | undefined} Array of child node IDs, or `undefined` if the node does not exist.
+   * Gets list of direct children of node v.
+   *
+   * @param {NodeID | number} [v] - Node ID. If not specified, gets nodes
+   * with no parent (top-level nodes).
+   * @returns {NodeID[] | undefined} all nodes that are children of node `v` or
+   * `undefined` if node `v` is not in the graph.
+   * Always returns `[]` for graphs that are not compound.
+   * @remarks Takes `O(|V|)` time.
    */
   children(v) {
     if (_.isUndefined(v)) {
@@ -423,7 +640,11 @@ export class Graph {
 
   /**
    * @param {NodeID | number} v - Node ID.
-   * @returns {NodeID[] | undefined} Array of predecessor (nodes that have an edge to this node) node IDs, or `undefined` if the node does not exist.
+   * @returns {NodeID[] | undefined} all nodes that are predecessors of the
+   * specified node or `undefined` if node `v` is not in the graph.
+   * @remarks
+   * Behavior is undefined for undirected graphs - use {@link neighbors} instead.
+   * Takes `O(|V|)` time.
    */
   predecessors(v) {
     var predsV = this._preds[v];
@@ -434,7 +655,11 @@ export class Graph {
 
   /**
    * @param {NodeID | number} v - Node ID.
-   * @returns {NodeID[] | undefined} Array of successor (nodes that this node has an edge to) node IDs, or `undefined` if the node does not exist.
+   * @returns {NodeID[] | undefined} all nodes that are successors of the
+   * specified node or `undefined` if node `v` is not in the graph.
+   * @remarks
+   * Behavior is undefined for undirected graphs - use {@link neighbors} instead.
+   * Takes `O(|V|)` time.
    */
   successors(v) {
     var sucsV = this._sucs[v];
@@ -445,7 +670,10 @@ export class Graph {
 
   /**
    * @param {NodeID | number} v - Node ID.
-   * @returns {NodeID[] | undefined} Array of neighbor (nodes that share one of the same predecessors) node IDs, or `undefined` if the node does not exist.
+   * @returns {NodeID[] | undefined} all nodes that are predecessors or
+   * successors of the specified node
+   * or `undefined` if node `v` is not in the graph.
+   * @remarks Takes `O(|V|)` time.
    */
   neighbors(v) {
     var preds = this.predecessors(v);
@@ -469,8 +697,16 @@ export class Graph {
   }
 
   /**
+   * Creates new graph with nodes filtered via `filter`.
+   * Edges incident to rejected node
+   * are also removed.
+   * 
+   * In case of compound graph, if parent is rejected by `filter`,
+   * than all its children are rejected too.
+
    * @param {(v: NodeID) => boolean} filter - Function that returns `true` for nodes to keep.
    * @returns {Graph<GraphLabel, NodeLabel, EdgeLabel>} A new graph containing only the nodes for which `filter` returns `true`.
+   * @remarks Average-case complexity: O(|E|+|V|).
    */
   filterNodes(filter) {
     /**
@@ -523,7 +759,12 @@ export class Graph {
   /* === Edge functions ========== */
 
   /**
-   * @param {typeof this._defaultEdgeLabelFn | EdgeLabel} newDefault - Function that creates the default label for new edges, or a constant label.
+   * Sets a new default value that is assigned to edges that are created without
+   * a label.
+   *
+   * @param {typeof this._defaultEdgeLabelFn | EdgeLabel} newDefault - If a function,
+   * it is called with the parameters `(v, w, name)`.
+   * Otherwise, it is assigned as the label directly.
    * @returns {this}
    */
   setDefaultEdgeLabel(newDefault) {
@@ -533,18 +774,40 @@ export class Graph {
     this._defaultEdgeLabelFn = newDefault;
     return this;
   }
+
+  /**
+   * @returns {number} the number of edges in the graph.
+   * @remarks Complexity: O(1).
+   */
   edgeCount() {
     return this._edgeCount;
   }
+
+  /**
+   * Gets edges of the graph.
+   *
+   * @returns {EdgeObj[]} the {@link EdgeObj} for each edge in the graph.
+   *
+   * @remarks
+   * In case of compound graph subgraphs are not considered.
+   * Use {@link edge()} to get the label for each edge.
+   * Takes `O(|E|)` time.
+   */
   edges() {
     return _.values(this._edgeObjs);
   }
 
   /**
-   * Creates edges between the given Node IDs.
+   * Establish an edges path over the nodes in nodes list.
+   *
+   * If some edge is already exists, it will update its label, otherwise it will
+   * create an edge between pair of nodes with label provided or default label
+   * if no label provided.
+   *
    * @param {Collection<NodeID>} vs - List of node IDs to create edges between.
    * @param {EdgeLabel} [value] - If set, update all edges with this value.
    * @returns {this}
+   * @remarks Complexity: O(|nodes|).
    */
   setPath(vs, value) {
     var self = this;
@@ -561,24 +824,30 @@ export class Graph {
   }
 
   /**
-   * Create or set the given edge.
+   * Creates or updates the label for the edge (`v`, `w`) with the optionally
+   * supplied `name`.
    *
    * @overload
    * @param {EdgeObj} arg0 - Edge object.
-   * @param {EdgeLabel} [value] - If set, update the edge with this value.
-   * If not set and the edge is being created, calls the function set by {@link setDefaultEdgeLabel}.
-   * @returns {this}
+   * @param {EdgeLabel} [value] - If supplied, it is set as the label for the edge.
+   * If not supplied and the edge was created by this call then
+   * {@link setDefaultEdgeLabel} will be used to assign the edge's label.
+   * @returns {this} the graph, allowing this to be chained with other functions.
+   * @remarks Takes `O(1)` time.
    */
   /**
-   * Create or set the given edge.
+   * Creates or updates the label for the edge (`v`, `w`) with the optionally
+   * supplied `name`.
    *
    * @overload
    * @param {NodeID | number} v - Source node ID. Number values will be coerced to strings.
    * @param {NodeID | number} w - Target node ID. Number values will be coerced to strings.
-   * @param {EdgeLabel} [value] - If set, update the edge with this value.
-   * If not set and the edge is being created, calls the function set by {@link setDefaultEdgeLabel}.
-   * @param {string | number} [name] - Edge name.
-   * @returns {this}
+   * @param {EdgeLabel} [value] - If supplied, it is set as the label for the edge.
+   * If not supplied and the edge was created by this call then
+   * {@link setDefaultEdgeLabel} will be used to assign the edge's label.
+   * @param {string | number} [name] - Edge name. Only useful with multigraphs.
+   * @returns {this} the graph, allowing this to be chained with other functions.
+   * @remarks Takes `O(1)` time.
    */
   setEdge() {
     var v, w, name, value;
@@ -644,18 +913,30 @@ export class Graph {
   }
 
   /**
-   * Get the label for the given edge.
+   * Gets the label for the specified edge.
+   *
    * @overload
    * @param {EdgeObj} v - Edge object.
-   * @returns {EdgeLabel | undefined} The label, or `undefined` if the edge does not exist.
+   * @returns {EdgeLabel | undefined} the label for the edge (`v`, `w`) if the
+   * graph has an edge between `v` and `w` with the optional `name`.
+   * Returned `undefined` if there is no such edge in the graph.
+   * @remarks
+   * `v` and `w` can be interchanged for undirected graphs.
+   * Takes `O(1)` time.
    */
   /**
-   * Get the label for the given edge.
+   * Gets the label for the specified edge.
+   *
    * @overload
    * @param {NodeID | number} v - Source node ID.
    * @param {NodeID | number} w - Target node ID.
-   * @param {string | number} [name] - Edge name.
-   * @returns {EdgeLabel | undefined} The label, or `undefined` if the edge does not exist.
+   * @param {string | number} [name] - Edge name. Only useful with multigraphs.
+   * @returns {EdgeLabel | undefined} the label for the edge (`v`, `w`) if the
+   * graph has an edge between `v` and `w` with the optional `name`.
+   * Returned `undefined` if there is no such edge in the graph.
+   * @remarks
+   * `v` and `w` can be interchanged for undirected graphs.
+   * Takes `O(1)` time.
    */
   edge(v, w, name) {
     var e =
@@ -666,16 +947,30 @@ export class Graph {
   }
 
   /**
+   * Detects whether the graph contains specified edge or not.
+   *
    * @overload
    * @param {EdgeObj} v - Edge object.
-   * @returns {boolean} `true` if the edge exists, else `false`.
+   * @returns {boolean} `true` if the graph has an edge between `v` and `w`
+   * with the optional `name`.
+   * @remarks
+   * `v` and `w` can be interchanged for undirected graphs.
+   * No subgraphs are considered.
+   * Takes `O(1)` time.
    */
   /**
+   * Detects whether the graph contains specified edge or not.
+   *
    * @overload
    * @param {NodeID | number} v - Source node ID.
    * @param {NodeID | number} w - Target node ID.
-   * @param {string | number} [name] - Edge name.
-   * @returns {boolean} `true` if the edge exists, else `false`.
+   * @param {string | number} [name] - Edge name. Only useful with multigraphs.
+   * @returns {boolean} `true` if the graph has an edge between `v` and `w`
+   * with the optional `name`.
+   * @remarks
+   * `v` and `w` can be interchanged for undirected graphs.
+   * No subgraphs are considered.
+   * Takes `O(1)` time.
    */
   hasEdge(v, w, name) {
     var e =
@@ -686,16 +981,29 @@ export class Graph {
   }
 
   /**
+   * Removes the edge (`v`, `w`) if the graph has an edge between `v` and `w`
+   * with the optional `name`. If not this function does nothing.
+   *
    * @overload
    * @param {EdgeObj} v - Edge object.
    * @returns {this}
+   * @remarks
+   * `v` and `w` can be interchanged for undirected graphs.
+   * No subgraphs are considered.
+   * Takes `O(1)` time.
    */
   /**
+   * Removes the edge (`v`, `w`) if the graph has an edge between `v` and `w`
+   * with the optional `name`. If not this function does nothing.
+   *
    * @overload
    * @param {NodeID | number} v - Source node ID.
    * @param {NodeID | number} w - Target node ID.
-   * @param {string | number} [name] - Edge name.
+   * @param {string | number} [name] - Edge name. Only useful with multigraphs.
    * @returns {this}
+   * @remarks
+   * `v` and `w` can be interchanged for undirected graphs.
+   * Takes `O(1)` time.
    */
   removeEdge(v, w, name) {
     var e =
@@ -719,8 +1027,13 @@ export class Graph {
 
   /**
    * @param {NodeID | number} v - Target node ID.
-   * @param {NodeID | number} [u] - If set, filters edges to only those between nodes `v` and `u`.
-   * @returns {EdgeObj[] | undefined} Array of incoming edges to node `v`, or `undefined` if node `v` does not exist.
+   * @param {NodeID | number} [u] - Optionally filters edges down to just those
+   * coming from node `u`.
+   * @returns {EdgeObj[] | undefined} all edges that point to the node `v`.
+   * Returns `undefined` if node `v` is not in the graph.
+   * @remarks
+   * Behavior is undefined for undirected graphs - use {@link nodeEdges} instead.
+   * Takes `O(|E|)` time.
    */
   inEdges(v, u) {
     var inV = this._in[v];
@@ -737,8 +1050,13 @@ export class Graph {
 
   /**
    * @param {NodeID | number} v - Target node ID.
-   * @param {NodeID | number} [w] - If set, filters edges to only those between nodes `v` and `w`.
-   * @returns {EdgeObj[] | undefined} Array of outgoing edges to node `v`, or `undefined` if node `v` does not exist.
+   * @param {NodeID | number} [w] - Optionally filters edges down to just those
+   * that point to `w`.
+   * @returns {EdgeObj[] | undefined} all edges that point to the node `v`.
+   * Returns `undefined` if node `v` is not in the graph.
+   * @remarks
+   * Behavior is undefined for undirected graphs - use {@link nodeEdges} instead.
+   * Takes `O(|E|)` time.
    */
   outEdges(v, w) {
     var outV = this._out[v];
@@ -754,10 +1072,12 @@ export class Graph {
   }
 
   /**
-   * List of all edges to/from node `v`.
    * @param {NodeID | number} v - Target Node ID.
-   * @param {NodeID | number} [w] - If set, filters edges to only those between nodes `v` and `w`.
-   * @returns {EdgeObj[] | undefined} Array of edges to/from node `v`, or `undefined` if node `v` does not exist.
+   * @param {NodeID | number} [w] - If set, filters those edges down to just
+   * those between nodes `v` and `w` regardless of direction
+   * @returns {EdgeObj[] | undefined} all edges to or from node `v` regardless
+   * of direction. Returns `undefined` if node `v` is not in the graph.
+   * @remarks Takes `O(|E|)` time.
    */
   nodeEdges(v, w) {
     var inEdges = this.inEdges(v, w);

--- a/src/graphlib/graph.test.js
+++ b/src/graphlib/graph.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { Graph } from './graph.js';
 

--- a/src/graphlib/graph.test.js
+++ b/src/graphlib/graph.test.js
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { Graph } from './graph.js';
 
 describe('Graph', function () {
+  /** @type {Graph} */
   var g;
 
   beforeEach(function () {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmit": false
+  },
+  "exclude": ["src/**/*.test.js"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,10 @@
 {
   "compilerOptions": {
     "checkJs": true,
-    "declaration": true,
-    "emitDeclarationOnly": true,
+    "noEmit": true,
     "lib": ["dom", "dom.iterable", "es2020"],
+    "skipLibCheck": true,
     "module": "node16"
   },
-  "include": ["src/**/*.js"],
-  "exclude": ["src/**/*.test.js"]
+  "include": ["src/**/*.js"]
 }


### PR DESCRIPTION
Similar to https://github.com/tbo47/dagre-es/pull/45, I've gone through the `src/graphlib/graph.js` file and added proper types to the functions whenever TypeScript couldn't automatically figure out the types.

I've also added type-checking of the `*.test.js` files to ensure that at least the types match what the unit tests expect!

### Stuff I didn't do and why

There's also an MIT-licensed [`@types/graphlib`][1] package that we can copy code from, but I didn't do that since I noticed issues with it that were causing our unit tests to fail type-checking (e.g. not allowing `number` params for lots of functions, even though the test code uses it a lot). We could copy it over later if we want to have better descriptions for the graphlib functions.

[1]: http://npmjs.com/package/@types/graphlib

I also tried to apply 8740b83207d639ff9bfd61a5117e381db8db474a from https://github.com/tbo47/dagre-es/pull/45 and unfortunately it seemed to cause errors in other parts of the code, since they're still not typed properly. But all the graphlib types looked correct to me.