### PR TITLE
Add `graphlib/alg` and `graphlib/data` JSDoc TypeScript types

### DIFF
--- a/src/graphlib/alg/components.js
+++ b/src/graphlib/alg/components.js
@@ -1,12 +1,51 @@
 import * as _ from 'lodash-es';
 
+/**
+ * @import { Graph, NodeID } from '../graph.js';
+ */
+
 export { components };
 
+/**
+ * Finds all [connected components][] in a graph and returns an array of these
+ * components. Each component is itself an array that contains the ids of nodes
+ * in the component.
+ *
+ * [connected components]: http://en.wikipedia.org/wiki/Connected_component_(graph_theory)
+ *
+ * @example
+ *
+ * ![](https://github.com/cpettitt/graphlib/wiki/images/components.png)
+ *
+ * ```js
+ * graphlib.alg.components(g);
+ * // => [ [ 'A', 'B', 'C', 'D' ],
+ * //      [ 'E', 'F', 'G' ],
+ * //      [ 'H', 'I' ] ]
+ * ```
+ *
+ * @param {Graph} g - The graph to find components in.
+ * @returns {NodeID[][]} An array of components, each of which is an array of node IDs.
+ *
+ * @remarks This function takes `O(|V|)` time.
+ */
 function components(g) {
+  /**
+   * @type {Record<NodeID, true>}
+   */
   var visited = {};
+  /**
+   * @type {NodeID[][]}
+   */
   var cmpts = [];
+  /**
+   * @type {NodeID[]}
+   */
   var cmpt;
 
+  /**
+   * @param {NodeID} v - The node to visit.
+   */
   function dfs(v) {
     if (Object.prototype.hasOwnProperty.call(visited, v)) return;
     visited[v] = true;

--- a/src/graphlib/alg/components.js
+++ b/src/graphlib/alg/components.js
@@ -15,7 +15,7 @@ export { components };
  *
  * @example
  *
- * ![](https://github.com/cpettitt/graphlib/wiki/images/components.png)
+ * ![](https://github.com/dagrejs/graphlib/wiki/images/components.png)
  *
  * ```js
  * graphlib.alg.components(g);

--- a/src/graphlib/alg/dfs.js
+++ b/src/graphlib/alg/dfs.js
@@ -1,23 +1,32 @@
 import * as _ from 'lodash-es';
 
+/**
+ * @import { Graph, NodeID } from '../graph.js';
+ */
+
 export { dfs };
 
-/*
+/**
  * A helper that preforms a pre- or post-order traversal on the input graph
  * and returns the nodes in the order they were visited. If the graph is
  * undirected then this algorithm will navigate using neighbors. If the graph
  * is directed then this algorithm will navigate using successors.
  *
- * Order must be one of "pre" or "post".
+ * @param {Graph} g - Input graph.
+ * @param {NodeID[] | NodeID} vs - Starting node or array of nodes.
+ * @param {'post' | 'pre'} order - The order to use. Must be one of "pre" or "post".
+ * @returns {NodeID[]} The nodes in the order they were visited.
  */
 function dfs(g, vs, order) {
   if (!_.isArray(vs)) {
     vs = [vs];
   }
 
+  /** @type {Parameters<typeof doDfs>[4]} */
   var navigation = (g.isDirected() ? g.successors : g.neighbors).bind(g);
-
+  /** @type {Parameters<typeof doDfs>[5]} */
   var acc = [];
+  /** @type {Parameters<typeof doDfs>[3]} */
   var visited = {};
   _.each(vs, function (v) {
     if (!g.hasNode(v)) {
@@ -29,6 +38,15 @@ function dfs(g, vs, order) {
   return acc;
 }
 
+/**
+ * @param {Graph} g - Input graph.
+ * @param {NodeID} v - The node to visit.
+ * @param {boolean} postorder - Whether to do postorder traversal.
+ * @param {Record<NodeID, true>} visited - Visited nodes.
+ * @param {(node: NodeID) => (NodeID[] | undefined)} navigation - Function to get
+ * neighbors/successors.
+ * @param {NodeID[]} acc - Accumulator for visited nodes.
+ */
 function doDfs(g, v, postorder, visited, navigation, acc) {
   if (!Object.prototype.hasOwnProperty.call(visited, v)) {
     visited[v] = true;

--- a/src/graphlib/alg/dijkstra-all.js
+++ b/src/graphlib/alg/dijkstra-all.js
@@ -1,11 +1,68 @@
 import * as _ from 'lodash-es';
 import { dijkstra } from './dijkstra.js';
 
+/**
+ * @import { EdgeObj, Graph, NodeID } from '../graph.js';
+ */
+
 export { dijkstraAll };
 
+/**
+ * This function finds the shortest path from each node to every other
+ * reachable node in the graph. It is similar to
+ * {@link dijkstra}, but instead of returning a single-source
+ * array, it returns a mapping of of `source -> alg.dijksta(g, source,
+ * weightFn, edgeFn)`.
+ *
+ * @remarks This function takes `O(|V| * (|E| + |V|) * log |V|)` time.
+ *
+ * @example
+ *
+ * ![](https://github.com/dagrejs/graphlib/wiki/images/dijkstra-source.png)
+ *
+ * ```js
+ * function weight(e) { return g.edge(e); }
+ *
+ * graphlib.alg.dijkstraAll(g, function(e) { return g.edge(e); });
+ *
+ * // => { A:
+ * //       { A: { distance: 0 },
+ * //         B: { distance: 6, predecessor: 'C' },
+ * //         C: { distance: 4, predecessor: 'A' },
+ * //         D: { distance: 2, predecessor: 'A' },
+ * //         E: { distance: 8, predecessor: 'F' },
+ * //         F: { distance: 4, predecessor: 'D' } },
+ * //      B:
+ * //       { A: { distance: Infinity },
+ * //         B: { distance: 0 },
+ * //         C: { distance: Infinity },
+ * //         D: { distance: Infinity },
+ * //         E: { distance: 6, predecessor: 'B' },
+ * //         F: { distance: Infinity } },
+ * //      C: { ... },
+ * //      D: { ... },
+ * //      E: { ... },
+ * //      F: { ... } }
+ * ```
+ *
+ * @param {Graph} g - Input graph.
+ * @param {(e: EdgeObj) => number} [weightFunc] - Optional function that returns
+ * the weight for edge `e`. If no `weightFn` is supplied then each edge is
+ * assumed to have a weight of 1.
+ * @param {(v: NodeID) => EdgeObj[]} [edgeFunc] - Optional function that returns
+ * the ids of all edges incident to the node `v` for the purposes of shortest
+ * path traversal. By default this function uses the {@link Graph.outEdges}.
+ * @returns {Record<NodeID, ReturnType<typeof dijkstra>>} a mapping of of
+ * `source -> alg.dijksta(g, source, weightFn, edgeFn)`.
+ * @throws {Error} If any of the traversed edges has a negative edge weight.
+ */
 function dijkstraAll(g, weightFunc, edgeFunc) {
   return _.transform(
     g.nodes(),
+    /**
+     * @param {Record<NodeID, ReturnType<typeof dijkstra>>} acc
+     * @param {NodeID} v
+     */
     function (acc, v) {
       acc[v] = dijkstra(g, v, weightFunc, edgeFunc);
     },

--- a/src/graphlib/alg/dijkstra-all.test.js
+++ b/src/graphlib/alg/dijkstra-all.test.js
@@ -20,6 +20,10 @@ describe('alg.dijkstraAll', function () {
   });
 });
 
+/**
+ * @param {Graph} g - The graph to generate a weight function for.
+ * @returns {Parameters<typeof dijkstraAll>[1]} A weight function for the graph `g`.
+ */
 function weight(g) {
   return function (e) {
     return g.edge(e);

--- a/src/graphlib/alg/dijkstra.js
+++ b/src/graphlib/alg/dijkstra.js
@@ -1,10 +1,64 @@
 import * as _ from 'lodash-es';
 import { PriorityQueue } from '../data/priority-queue.js';
 
+/**
+ * @import { EdgeObj, Graph, NodeID } from '../graph.js';
+ */
+
 export { dijkstra };
 
 var DEFAULT_WEIGHT_FUNC = _.constant(1);
 
+/**
+ * @typedef {Object} PathEntry
+ * @property {number} distance The sum of the weights from `source` to `v`
+ * along the shortest path or `Number.POSITIVE_INFINITY` if there is no path
+ * from `source`.
+ * @property {NodeID} [predecessor] Can be used to walk the individual
+ * elements of the path from `source` to `v` in reverse order.
+ */
+
+/**
+ * This function is an implementation of [Dijkstra's algorithm][] which finds
+ * the shortest path from `source` to all other nodes in `g`. This
+ * function returns
+ *
+ * [Dijkstra's algorithm]: http://en.wikipedia.org/wiki/Dijkstra%27s_algorithm
+ *
+ * @example
+ *
+ * ![](https://github.com/dagrejs/graphlib/wiki/images/dijkstra-source.png)
+ * <!-- SOURCE:
+ * http://dagrejs.github.io/project/dagre-d3/latest/demo/interactive-demo.html?graph=digraph%20%7B%0Anode%20%5Bshape%3Dcircle%2C%20style%3D%22fill%3Awhite%3Bstroke%3A%23333%3Bstroke-width%3A1.5px%22%5D%0Aedge%20%5Blabeloffset%3D2%20labelpos%3Dr%5D%0Arankdir%3Dlr%0A%20%20A%20-%3E%20B%5Blabel%3D10%5D%0A%20%20A%20-%3E%20C%5Blabel%3D4%5D%0A%20%20A%20-%3E%20D%5Blabel%3D2%5D%0A%20%20C%20-%3E%20B%5Blabel%3D2%5D%0A%20%20C%20-%3E%20D%5Blabel%3D8%5D%0A%20%20B%20-%3E%20E%5Blabel%3D6%5D%0A%20%20D%20-%3E%20F%5Blabel%3D2%5D%0A%20%20F%20-%3E%20E%5Blabel%3D4%5D%0A%7D
+ * -->
+ *
+ * ```js
+ * function weight(e) { return g.edge(e); }
+ *
+ * graphlib.alg.dijkstra(g, "A", weight);
+ * // => { A: { distance: 0 },
+ * //      B: { distance: 6, predecessor: 'C' },
+ * //      C: { distance: 4, predecessor: 'A' },
+ * //      D: { distance: 2, predecessor: 'A' },
+ * //      E: { distance: 8, predecessor: 'F' },
+ * //      F: { distance: 4, predecessor: 'D' } }
+ * ```
+ *
+ * @remarks It takes `O((|E| + |V|) * log |V|)` time.
+ *
+ * @param {Graph} g - Input graph.
+ * @param {NodeID | number} source - The source node id. Converted to a string.
+ * @param {(e: EdgeObj) => number} [weightFn] - Optional function that returns
+ * the weight for edge `e`. If no `weightFn` is supplied then each edge is
+ * assumed to have a weight of 1.
+ * @param {(v: NodeID) => EdgeObj[]} [edgeFn] - Optional function that returns
+ * the ids of all edges incident to the node `v` for the purposes of shortest
+ * path traversal.
+ * By default this function uses the {@link Graph.outEdges} function on the
+ * supplied graph.
+ * @returns {Record<NodeID, PathEntry>} a map of `v -> { distance, predecessor }`.
+ * @throws {Error} If any of the traversed edges has a negative edge weight.
+ */
 function dijkstra(g, source, weightFn, edgeFn) {
   return runDijkstra(
     g,
@@ -17,11 +71,22 @@ function dijkstra(g, source, weightFn, edgeFn) {
   );
 }
 
+/**
+ * @param {Graph} g - Input graph.
+ * @param {NodeID} source - The source node id.
+ * @param {(e: EdgeObj) => number} weightFn - Required weight function.
+ * @param {(v: NodeID) => EdgeObj[]} edgeFn - Required edge function.
+ */
 function runDijkstra(g, source, weightFn, edgeFn) {
+  /** @type {Record<NodeID, PathEntry>} */
   var results = {};
   var pq = new PriorityQueue();
-  var v, vEntry;
+  /** @type {NodeID} */
+  var v;
+  /** @type {PathEntry} */
+  var vEntry;
 
+  /** @param {EdgeObj} edge */
   var updateNeighbors = function (edge) {
     var w = edge.v !== v ? edge.v : edge.w;
     var wEntry = results[w];

--- a/src/graphlib/alg/dijkstra.test.js
+++ b/src/graphlib/alg/dijkstra.test.js
@@ -89,6 +89,10 @@ describe('alg.dijkstra', function () {
   });
 });
 
+/**
+ * @param {Graph} g - The graph to generate a weight function for.
+ * @returns {Parameters<typeof dijkstra>[2]} A weight function for the graph `g`.
+ */
 function weightFn(g) {
   return function (e) {
     return g.edge(e);

--- a/src/graphlib/alg/find-cycles.js
+++ b/src/graphlib/alg/find-cycles.js
@@ -1,8 +1,52 @@
 import * as _ from 'lodash-es';
 import { tarjan } from './tarjan.js';
 
+/**
+ * @import { Graph, NodeID } from '../graph.js';
+ */
+
 export { findCycles };
 
+/**
+ * Given a Graph, `g`, this function returns all nodes that
+ * are part of a cycle. As there may be more than one cycle in a graph this
+ * function return an array of these cycles, where each cycle is itself
+ * represented by an array of ids for each node involved in that cycle.
+ *
+ * @remarks
+ *
+ * {@link isAcyclic} is more efficient if you only need to
+ * determine whether a graph has a cycle or not.
+ *
+ * @example
+ *
+ * ```js
+ * var g = new graphlib.Graph();
+ * g.setNode(1);
+ * g.setNode(2);
+ * g.setNode(3);
+ * g.setEdge(1, 2);
+ * g.setEdge(2, 3);
+ *
+ * graphlib.alg.findCycles(g);
+ * // => []
+ *
+ * g.setEdge(3, 1);
+ * graphlib.alg.findCycles(g);
+ * // => [ [ '3', '2', '1' ] ]
+ *
+ * g.setNode(4);
+ * g.setNode(5);
+ * g.setEdge(4, 5);
+ * g.setEdge(5, 4);
+ * graphlib.alg.findCycles(g);
+ * // => [ [ '3', '2', '1' ], [ '5', '4' ] ]
+ * ```
+ *
+ * @param {Graph} g - The graph to analyze.
+ * @returns {NodeID[][]} An array of cycles. Each cycle is itself an array
+ * that contains the ids of all nodes in the cycle.
+ */
 function findCycles(g) {
   return _.filter(tarjan(g), function (cmpt) {
     return cmpt.length > 1 || (cmpt.length === 1 && g.hasEdge(cmpt[0], cmpt[0]));

--- a/src/graphlib/alg/find-cycles.test.js
+++ b/src/graphlib/alg/find-cycles.test.js
@@ -3,6 +3,10 @@ import { describe, expect, it } from 'vitest';
 import { Graph } from '../graph.js';
 import { findCycles } from './find-cycles.js';
 
+/**
+ * @import { NodeID } from '../graph.js';
+ */
+
 describe('alg.findCycles', function () {
   it('returns an empty array for an empty graph', function () {
     expect(findCycles(new Graph())).to.eql([]);
@@ -42,7 +46,12 @@ describe('alg.findCycles', function () {
   });
 });
 
-// A helper that sorts components and their contents
+/**
+ * A helper that sorts components and their contents
+ *
+ * @param {NodeID[][]} cmpts - The components to sort.
+ * @returns {NodeID[][]} The sorted components.
+ */
 function sort(cmpts) {
   return cmpts.map((cmpt) => cmpt.sort()).sort((a, b) => a[0].localeCompare(b[0]));
 }

--- a/src/graphlib/alg/floyd-warshall.js
+++ b/src/graphlib/alg/floyd-warshall.js
@@ -1,9 +1,66 @@
 import * as _ from 'lodash-es';
 
+/**
+ * @import { Graph, EdgeObj, NodeID } from '../graph.js';
+ * @import { PathEntry } from './dijkstra.js';
+ */
+
 export { floydWarshall };
 
 var DEFAULT_WEIGHT_FUNC = _.constant(1);
 
+/**
+ * This function is an implementation of the [Floyd-Warshall algorithm][],
+ * which finds the shortest path from each node to every other reachable node
+ * in the graph. It is similar to {@link dijkstraAll}, but
+ * it handles negative edge weights and is more efficient for some types of
+ * graphs.
+ *
+ * [Floyd-Warshall algorithm]: https://en.wikipedia.org/wiki/Floyd-Warshall_algorithm
+ *
+ * @remarks This algorithm takes `O(|V|^3)` time.
+ *
+ * @example
+ *
+ * ![](https://github.com/dagrejs/graphlib/wiki/images/dijkstra-source.png)
+ *
+ * ```js
+ * function weight(e) { return g.edge(e); }
+ *
+ * graphlib.alg.floydWarshall(g, function(e) { return g.edge(e); });
+ *
+ * // => { A:
+ * //       { A: { distance: 0 },
+ * //         B: { distance: 6, predecessor: 'C' },
+ * //         C: { distance: 4, predecessor: 'A' },
+ * //         D: { distance: 2, predecessor: 'A' },
+ * //         E: { distance: 8, predecessor: 'F' },
+ * //         F: { distance: 4, predecessor: 'D' } },
+ * //      B:
+ * //       { A: { distance: Infinity },
+ * //         B: { distance: 0 },
+ * //         C: { distance: Infinity },
+ * //         D: { distance: Infinity },
+ * //         E: { distance: 6, predecessor: 'B' },
+ * //         F: { distance: Infinity } },
+ * //      C: { ... },
+ * //      D: { ... },
+ * //      E: { ... },
+ * //      F: { ... } }
+ * ```
+ *
+ * @param {Graph} g - The graph to analyze.
+ * @param {(e: EdgeObj) => number} [weightFn] - Optional function that returns
+ * the weight for edge `e`. If no `weightFn` is supplied then each edge is
+ * assumed to have a weight of 1.
+ * @param {(v: NodeID) => EdgeObj[]} [edgeFn] - Optional function that returns
+ * the ids of all edges incident to the node `v` for the purposes of shortest
+ * path traversal.
+ * By default this function uses the {@link Graph.outEdges} function on the
+ * supplied graph.
+ * @returns {Record<NodeID, Record<NodeID, PathEntry>>} a map of
+ * `source -> { target -> { distance, predecessor }`.
+ */
 function floydWarshall(g, weightFn, edgeFn) {
   return runFloydWarshall(
     g,
@@ -15,7 +72,13 @@ function floydWarshall(g, weightFn, edgeFn) {
   );
 }
 
+/**
+ * @param {Graph} g - Input graph.
+ * @param {(e: EdgeObj) => number} weightFn - Required weight function.
+ * @param {(v: NodeID) => EdgeObj[]} edgeFn - Required edge function.
+ */
 function runFloydWarshall(g, weightFn, edgeFn) {
+  /** @type {Record<NodeID, Record<NodeID, PathEntry>>} */
   var results = {};
   var nodes = g.nodes();
 

--- a/src/graphlib/alg/floyd-warshall.test.js
+++ b/src/graphlib/alg/floyd-warshall.test.js
@@ -56,6 +56,10 @@ describe('alg.floydWarshall', function () {
   });
 });
 
+/**
+ * @param {Graph} g - The graph to generate a weight function for.
+ * @returns {Parameters<typeof floydWarshall>[1]} A weight function for the graph `g`.
+ */
 function weightFn(g) {
   return function (edge) {
     return g.edge(edge);

--- a/src/graphlib/alg/is-acyclic.js
+++ b/src/graphlib/alg/is-acyclic.js
@@ -1,7 +1,42 @@
 import { topsort, CycleException } from './topsort.js';
 
+/**
+ * @import { Graph } from '../graph.js';
+ */
+
 export { isAcyclic };
 
+/**
+ * Given a Graph, `g`, this function returns `true` if the
+ * graph has no cycles and returns `false` if it does.
+ *
+ * @remarks
+ * This algorithm returns
+ * as soon as it detects the first cycle. You can use
+ * {@link ../findCycles} to get the actual list of cycles in the
+ * graph.
+ *
+ * @example
+ *
+ * ```js
+ * var g = new graphlib.Graph();
+ * g.setNode(1);
+ * g.setNode(2);
+ * g.setNode(3);
+ * g.setEdge(1, 2);
+ * g.setEdge(2, 3);
+ *
+ * graphlib.alg.isAcyclic(g);
+ * // => true
+ *
+ * g.setEdge(3, 1);
+ * graphlib.alg.isAcyclic(g);
+ * // => false
+ * ```
+ *
+ * @param {Graph} g - The graph to analyze.
+ * @returns {boolean} `true` if the graph is acyclic, `false` otherwise.
+ */
 function isAcyclic(g) {
   try {
     topsort(g);

--- a/src/graphlib/alg/postorder.js
+++ b/src/graphlib/alg/postorder.js
@@ -2,6 +2,30 @@ import { dfs } from './dfs.js';
 
 export { postorder };
 
+/**
+ * This function performs a [postorder traversal][] of the graph `g` starting
+ * at the nodes `vs`. For each node visited, `v`,  the function `callback(v)`
+ * is called.
+ *
+ * [postorder traversal]: https://en.wikipedia.org/wiki/Tree_traversal#Depth-first
+ *
+ * @example
+ *
+ * ![](https://github.com/dagrejs/graphlib/wiki/images/preorder.png)
+ *
+ * ```js
+ * graphlib.alg.postorder(g, "A");
+ * // => One of:
+ * // [ "B", "D", "E", C", "A" ]
+ * // [ "B", "E", "D", C", "A" ]
+ * // [ "D", "E", "C", B", "A" ]
+ * // [ "E", "D", "C", B", "A" ]
+ * ```
+ *
+ * @param {Parameters<typeof dfs>[0]} g - The graph to traverse.
+ * @param {Parameters<typeof dfs>[1]} vs - Nodes to start the traversal from.
+ * @returns {ReturnType<typeof dfs>} The nodes in the order they were visited.
+ */
 function postorder(g, vs) {
   return dfs(g, vs, 'post');
 }

--- a/src/graphlib/alg/preorder.js
+++ b/src/graphlib/alg/preorder.js
@@ -2,6 +2,33 @@ import { dfs } from './dfs.js';
 
 export { preorder };
 
+/**
+ * This function performs a [preorder traversal][] of the graph `g` starting
+ * at the nodes `vs`. For each node visited, `v`,  the function `callback(v)`
+ * is called.
+ *
+ * [preorder traversal]: https://en.wikipedia.org/wiki/Tree_traversal#Depth-first
+ *
+ * @example
+ *
+ * ![](https://github.com/dagrejs/graphlib/wiki/images/preorder.png)
+ * <!-- SOURCE:
+ * http://dagrejs.github.io/project/dagre-d3/latest/demo/interactive-demo.html?graph=digraph%20%7B%0Anode%20%5Bshape%3Dcircle%2C%20style%3D%22fill%3Awhite%3Bstroke%3A%23333%3Bstroke-width%3A1.5px%22%5D%0Aedge%20%5Blabeloffset%3D2%20labelpos%3Dr%5D%0Arankdir%3Dlr%0A%20%20A%20-%3E%20B%0A%20%20A%20-%3E%20C%0A%20%20C%20-%3E%20D%0A%20%20C%20-%3E%20E%0A%7D
+ * -->
+ *
+ * ```js
+ * graphlib.alg.preorder(g, "A");
+ * // => One of:
+ * // [ "A", "B", "C", "D", "E" ]
+ * // [ "A", "B", "C", "E", "D" ]
+ * // [ "A", "C", "D", "E", "B" ]
+ * // [ "A", "C", "E", "D", "B" ]
+ * ```
+ *
+ * @param {Parameters<typeof dfs>[0]} g - The graph to traverse.
+ * @param {Parameters<typeof dfs>[1]} vs - Nodes to start the traversal from.
+ * @returns {ReturnType<typeof dfs>} The nodes in the order they were visited.
+ */
 function preorder(g, vs) {
   return dfs(g, vs, 'pre');
 }

--- a/src/graphlib/alg/prim.js
+++ b/src/graphlib/alg/prim.js
@@ -2,14 +2,80 @@ import * as _ from 'lodash-es';
 import { PriorityQueue } from '../data/priority-queue.js';
 import { Graph } from '../graph.js';
 
+/**
+ * @import { EdgeObj, NodeID } from '../graph.js';
+ */
+
 export { prim };
 
+/**
+ * [Prim's algorithm][] takes a connected undirected graph and generates a
+ * [minimum spanning tree][]. This function returns the minimum spanning
+ * tree as an undirected graph. This algorithm is derived from the description
+ * in "Introduction to Algorithms", Third Edition, Cormen, et al., Pg 634.
+ *
+ * [Prim's algorithm]: https://en.wikipedia.org/wiki/Prim's_algorithm
+ * [minimum spanning tree]: https://en.wikipedia.org/wiki/Minimum_spanning_tree
+ *
+ * @remarks This function takes `O(|E| log |V|)` time.
+ *
+ * @example
+ *
+ * ![](https://github.com/dagrejs/graphlib/wiki/images/prim-input.png)
+ * <!-- SOURCE:
+ * digraph {
+ * node [shape=circle, style="fill:white;stroke:#333;stroke-width:1.5px"]
+ * edge [labeloffset=2 labelpos=r arrowhead="none"]
+ * rankdir=lr
+ * A -> B [label=3]
+ * A -> D [label=12]
+ * B -> C [label=6]
+ * B -> D [label=1]
+ * C -> D [label=1]
+ * D -> E [label=2]
+ * C -> E [label=9]
+ * }
+ * -->
+ *
+ * ```js
+ * function weight(e) { return g(e); }
+ * graphlib.alg.prim(g, weight);
+ * ```
+ *
+ * Returns a tree (represented as a Graph) of the following form:
+ *
+ * ![](https://github.com/dagrejs/graphlib/wiki/images/prim-output.png)
+ * <!-- SOURCE:
+ * digraph {
+ * node [shape=circle, style="fill:white;stroke:#333;stroke-width:1.5px"]
+ * edge [labeloffset=2 labelpos=r arrowhead="none"]
+ * rankdir=lr
+ * A -> B
+ * B -> D
+ * C -> D
+ * D -> E
+ * }
+ * -->
+ *
+ * @param {Graph} g - The input undirected connected graph.
+ * @param {(e: EdgeObj) => number} weightFunc - Function that returns
+ * the weight for edge `e`.
+ * @returns {Graph<undefined, undefined, undefined>} The minimum spanning tree
+ * as an undirected graph.
+ * @throws {Error} If the input graph is not connected.
+ */
 function prim(g, weightFunc) {
   var result = new Graph();
+  /** @type {Record<NodeID, NodeID>} */
   var parents = {};
   var pq = new PriorityQueue();
+  /** @type {NodeID} */
   var v;
 
+  /**
+   * @param {EdgeObj} edge - Edge to examine for possible inclusion in the
+   * minimum spanning tree.
+   */
   function updateNeighbors(edge) {
     var w = edge.v === v ? edge.w : edge.v;
     var pri = pq.priority(w);

--- a/src/graphlib/alg/prim.test.js
+++ b/src/graphlib/alg/prim.test.js
@@ -51,6 +51,10 @@ describe('alg.prim', function () {
   });
 });
 
+/**
+ * @param {Graph} g - The graph to generate a weight function for.
+ * @returns {Parameters<typeof prim>[1]} A weight function for the graph `g`.
+ */
 function weightFn(g) {
   return function (edge) {
     return g.edge(edge);

--- a/src/graphlib/alg/tarjan.js
+++ b/src/graphlib/alg/tarjan.js
@@ -1,11 +1,64 @@
+/**
+ * @import { Graph, NodeID } from '../graph.js';
+ */
+
 export { tarjan };
 
+/**
+ * This function is an implementation of [Tarjan's algorithm][] which finds
+ * all [strongly connected components][] in the directed graph `g`. Each
+ * strongly connected component is composed of nodes that can reach all other
+ * nodes in the component via directed edges. A strongly connected component
+ * can consist of a single node if that node cannot both reach and be reached
+ * by any other specific node in the graph. Components of more than one node
+ * are guaranteed to have at least one cycle.
+ *
+ * [Tarjan's algorithm]: http://en.wikipedia.org/wiki/Tarjan's_strongly_connected_components_algorithm
+ * [strongly connected components]: http://en.wikipedia.org/wiki/Strongly_connected_component
+ *
+ * @example
+ *
+ * ![](https://github.com/dagrejs/graphlib/wiki/images/tarjan.png)
+ * <!-- SOURCE:
+ * digraph {
+ * node [shape=circle, style="fill:white;stroke:#333;stroke-width:1.5px"]
+ * edge [lineInterpolate=bundle]
+ * rankdir=lr
+ *
+ * A -> B -> C -> D -> H -> G -> F
+ * F -> G
+ * D -> C
+ * H -> D
+ * B -> E -> G
+ * E -> A
+ * }
+ * -->
+ *
+ * ```js
+ * graphlib.alg.tarjan(g);
+ * // => [ [ 'F', 'G' ],
+ * //      [ 'H', 'D', 'C' ],
+ * //      [ 'E', 'B', 'A' ] ]
+ * ```
+ *
+ * @param {Graph} g - The directed graph to analyze.
+ * @returns {NodeID[][]} an array of components. Each component is itself an
+ * array that contains the ids of all nodes in the component.
+ */
 function tarjan(g) {
   var index = 0;
+  /** @type {NodeID[]} */
   var stack = [];
-  var visited = {}; // node id -> { onStack, lowlink, index }
+  /**
+   * @type {Record<NodeID, { onStack: boolean, lowlink: number, index: number }>}
+   */
+  var visited = {};
+  /** @type {NodeID[][]} */
   var results = [];
 
+  /**
+   * @param {NodeID} v - Node to recursively visit
+   */
   function dfs(v) {
     var entry = (visited[v] = {
       onStack: true,
@@ -24,7 +77,9 @@ function tarjan(g) {
     });
 
     if (entry.lowlink === entry.index) {
+      /** @type {NodeID[]} */
       var cmpt = [];
+      /** @type {NodeID} */
       var w;
       do {
         w = stack.pop();

--- a/src/graphlib/alg/tarjan.test.js
+++ b/src/graphlib/alg/tarjan.test.js
@@ -3,6 +3,10 @@ import { describe, expect, it } from 'vitest';
 import { Graph } from '../graph.js';
 import { tarjan } from './tarjan.js';
 
+/**
+ * @import { NodeID } from '../graph.js';
+ */
+
 describe('alg.tarjan', function () {
   it('returns an empty array for an empty graph', function () {
     expect(tarjan(new Graph())).to.eql([]);
@@ -36,7 +40,12 @@ describe('alg.tarjan', function () {
   });
 });
 
-// A helper that sorts components and their contents
+/**
+ * A helper that sorts components and their contents
+ *
+ * @param {NodeID[][]} cmpts - The components to sort.
+ * @returns {NodeID[][]} The sorted components.
+ */
 function sort(cmpts) {
   return cmpts.map((cmpt) => cmpt.sort()).sort((a, b) => a[0].localeCompare(b[0]));
 }

--- a/src/graphlib/alg/topsort.js
+++ b/src/graphlib/alg/topsort.js
@@ -1,14 +1,44 @@
 import * as _ from 'lodash-es';
 
+/**
+ * @import { Graph, NodeID } from '../graph.js';
+ */
+
 export { topsort, CycleException };
 
 topsort.CycleException = CycleException;
 
+/**
+ * An implementation of [topological sorting](https://en.wikipedia.org/wiki/Topological_sorting).
+ *
+ * @remarks Takes `O(|V| + |E|)` time.
+ *
+ * @example
+ *
+ * ![](https://github.com/dagrejs/graphlib/wiki/images/topsort.png)
+ *
+ * ```js
+ * graphlib.alg.topsort(g)
+ * // [ '1', '2', '3', '4' ] or [ '1', '3', '2', '4' ]
+ * ```
+ *
+ * @param {Graph} g - The graph to sort.
+ * @returns {NodeID[]} an array of nodes
+ * such that for each edge `u -> v`, `u` appears before `v` in the array.
+ * @throws {CycleException} If the graph has a cycle so that it is impossible
+ * to generate a topological sort.
+ */
 function topsort(g) {
+  /** @type {Record<NodeID, true>} */
   var visited = {};
+  /** @type {Record<NodeID, true>} */
   var stack = {};
+  /** @type {NodeID[]} */
   var results = [];
 
+  /**
+   * @param {NodeID} node - Node to recursively visit.
+   */
   function visit(node) {
     if (Object.prototype.hasOwnProperty.call(stack, node)) {
       throw new CycleException();
@@ -32,5 +62,8 @@ function topsort(g) {
   return results;
 }
 
+/**
+ * @class
+ */
 function CycleException() {}
 CycleException.prototype = new Error(); // must be an instance of Error to pass testing

--- a/src/graphlib/data/priority-queue.js
+++ b/src/graphlib/data/priority-queue.js
@@ -9,17 +9,27 @@ export { PriorityQueue };
  */
 class PriorityQueue {
   constructor() {
+    /**
+     * @private
+     * @type {Array<{key: string, priority: number}>}
+     */
     this._arr = [];
+    /**
+     * @private
+     * @type {Record<string, number>}
+     */
     this._keyIndices = {};
   }
   /**
-   * Returns the number of elements in the queue. Takes `O(1)` time.
+   * @returns {number} the number of elements in the queue.
+   * @remarks Takes `O(1)` time.
    */
   size() {
     return this._arr.length;
   }
   /**
-   * Returns the keys that are in the queue. Takes `O(n)` time.
+   * @returns {string[]} the keys that are in the queue.
+   * @remarks Takes `O(n)` time.
    */
   keys() {
     return this._arr.map(function (x) {
@@ -27,16 +37,17 @@ class PriorityQueue {
     });
   }
   /**
-   * Returns `true` if **key** is in the queue and `false` if not.
+   * @param {Object} key - The key to check for presence in the queue.
+   * @returns {boolean} `true` if **key** is in the queue and `false` if not.
    */
   has(key) {
     return Object.prototype.hasOwnProperty.call(this._keyIndices, key);
   }
   /**
-   * Returns the priority for **key**. If **key** is not present in the queue
-   * then this function returns `undefined`. Takes `O(1)` time.
-   *
-   * @param {Object} key
+   * @param {Object} key - The key to get the priority for.
+   * @returns {number | undefined} the priority for **key**.
+   * If **key** is not present in the queue then this function returns `undefined`.
+   * @remarks Takes `O(1)` time.
    */
   priority(key) {
     var index = this._keyIndices[key];
@@ -45,8 +56,9 @@ class PriorityQueue {
     }
   }
   /**
-   * Returns the key for the minimum element in this queue. If the queue is
-   * empty this function throws an Error. Takes `O(1)` time.
+   * @returns {string} the key for the minimum element in this queue.
+   * @throws {Error} if the queue is empty.
+   * @remarks Takes `O(1)` time.
    */
   min() {
     if (this.size() === 0) {
@@ -55,12 +67,14 @@ class PriorityQueue {
     return this._arr[0].key;
   }
   /**
-   * Inserts a new key into the priority queue. If the key already exists in
-   * the queue this function returns `false`; otherwise it will return `true`.
-   * Takes `O(n)` time.
+   * Inserts a new key into the priority queue.
    *
-   * @param {Object} key the key to add
+   * @remarks Takes `O(n)` time.
+   *
+   * @param {Object} key the key to add. This will be coerced to a `string`.
    * @param {Number} priority the initial priority for the key
+   * @returns {boolean} `true` if the key was added and `false` if it was already
+   * present in the queue.
    */
   add(key, priority) {
     var keyIndices = this._keyIndices;
@@ -76,7 +90,9 @@ class PriorityQueue {
     return false;
   }
   /**
-   * Removes and returns the smallest key in the queue. Takes `O(log n)` time.
+   * Removes and returns the smallest key in the queue.
+   * @returns {string} the key with the smallest priority
+   * @remarks Takes `O(log n)` time.
    */
   removeMin() {
     this._swap(0, this._arr.length - 1);
@@ -86,11 +102,11 @@ class PriorityQueue {
     return min.key;
   }
   /**
-   * Decreases the priority for **key** to **priority**. If the new priority is
-   * greater than the previous priority, this function will throw an Error.
+   * Decreases the priority for **key** to **priority**.
    *
    * @param {Object} key the key for which to raise priority
    * @param {Number} priority the new priority for the key
+   * @throws {Error} if the new priority is  greater than the previous priority.
    */
   decrease(key, priority) {
     var index = this._keyIndices[key];
@@ -108,6 +124,10 @@ class PriorityQueue {
     this._arr[index].priority = priority;
     this._decrease(index);
   }
+  /**
+   * @param {number} i - Lower index.
+   * @private
+   */
   _heapify(i) {
     var arr = this._arr;
     var l = 2 * i;
@@ -124,6 +144,10 @@ class PriorityQueue {
       }
     }
   }
+  /**
+   * @param {number} index - Index to decrease.
+   * @private
+   */
   _decrease(index) {
     var arr = this._arr;
     var priority = arr[index].priority;
@@ -137,6 +161,11 @@ class PriorityQueue {
       index = parent;
     }
   }
+  /**
+   * @param {number} i - First index
+   * @param {number} j - Second index
+   * @private
+   */
   _swap(i, j) {
     var arr = this._arr;
     var keyIndices = this._keyIndices;

--- a/src/graphlib/data/priority-queue.test.js
+++ b/src/graphlib/data/priority-queue.test.js
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { PriorityQueue } from './priority-queue.js';
 
 describe('data.PriorityQueue', function () {
+  /** @type {PriorityQueue} */
   var pq;
 
   beforeEach(function () {

--- a/src/graphlib/json.js
+++ b/src/graphlib/json.js
@@ -1,9 +1,64 @@
 import * as _ from 'lodash-es';
 import { Graph } from './graph.js';
 
+/**
+ * @import { NodeID, EdgeObj, GraphOptions } from './graph.js';
+ */
+
 export { write, read };
 
+/**
+ * @template [GraphLabel=any] - Label of the graph.
+ * @template [NodeLabel=any] - Label of a node.
+ * @template [EdgeLabel=any] - Label of an edge.
+ *
+ * @typedef {object} GraphJSON
+ * @property {Required<GraphOptions>} options - The options used to create the graph.
+ * @property {Array<{ v: NodeID; value?: NodeLabel; parent?: NodeID }>} nodes - The nodes in the graph.
+ * @property {Array<EdgeObj & { value?: EdgeLabel }>} edges - The edges in the graph.
+ * @property {GraphLabel} [value] - The graph's value, if any.
+ */
+
+/**
+ * Creates a JSON representation of the graph that can be serialized to a
+ * string with
+ * [JSON.stringify](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify).
+ * The graph can later be restored using {@link read}.
+ *
+ * @example
+ *
+ * ```js
+ * var g = new graphlib.Graph();
+ * g.setNode("a", { label: "node a" });
+ * g.setNode("b", { label: "node b" });
+ * g.setEdge("a", "b", { label: "edge a->b" });
+ * graphlib.json.write(g);
+ * // Returns the object:
+ * //
+ * // {
+ * //   "options": {
+ * //     "directed": true,
+ * //     "multigraph": false,
+ * //     "compound": false
+ * //   },
+ * //   "nodes": [
+ * //     { "v": "a", "value": { "label": "node a" } },
+ * //     { "v": "b", "value": { "label": "node b" } }
+ * //   ],
+ * //   "edges": [
+ * //     { "v": "a", "w": "b", "value": { "label": "edge a->b" } }
+ * //   ]
+ * // }
+ * ```
+ *
+ * @template [GraphLabel=any] - Label of the graph.
+ * @template [NodeLabel=any] - Label of a node.
+ * @template [EdgeLabel=any] - Label of an edge.
+ * @param {Graph<GraphLabel, NodeLabel, EdgeLabel>} g - The graph to serialize.
+ * @returns {GraphJSON<GraphLabel, NodeLabel, EdgeLabel>} The JSON representation of the graph.
+ */
 function write(g) {
+  /** @type {GraphJSON<GraphLabel, NodeLabel, EdgeLabel>} */
   var json = {
     options: {
       directed: g.isDirected(),
@@ -19,10 +74,17 @@ function write(g) {
   return json;
 }
 
+/**
+ * @template NodeLabel - Label of a node.
+ *
+ * @param {Graph<unknown, NodeLabel, unknown>} g - The graph to serialize.
+ * @returns {Array<{ v: NodeID; value?: NodeLabel; parent?: NodeID }>} The nodes in the graph.
+ */
 function writeNodes(g) {
   return _.map(g.nodes(), function (v) {
     var nodeValue = g.node(v);
     var parent = g.parent(v);
+    /** @type {{ v: NodeID; value?: NodeLabel; parent?: NodeID }} */
     var node = { v: v };
     if (!_.isUndefined(nodeValue)) {
       node.value = nodeValue;
@@ -34,9 +96,16 @@ function writeNodes(g) {
   });
 }
 
+/**
+ * @template EdgeLabel - Label of a node.
+ *
+ * @param {Graph<unknown, unknown, EdgeLabel>} g - The graph to serialize.
+ * @returns {Array<EdgeObj & { value?: EdgeLabel }>} The edges in the graph.
+ */
 function writeEdges(g) {
   return _.map(g.edges(), function (e) {
     var edgeValue = g.edge(e);
+    /** @type {EdgeObj & { value?: EdgeLabel }} */
     var edge = { v: e.v, w: e.w };
     if (!_.isUndefined(e.name)) {
       edge.name = e.name;
@@ -48,6 +117,31 @@ function writeEdges(g) {
   });
 }
 
+/**
+ * Takes JSON as input and returns the graph representation.
+ *
+ * @example
+ *
+ * For example, if we have serialized the graph in {@link write}
+ * to a string named `str`, we can restore it to a graph as follows:
+ *
+ * ```js
+ * var g2 = graphlib.json.read(JSON.parse(str));
+ * // or, in order to copy the graph
+ * var g3 = graphlib.json.read(graphlib.json.write(g))
+ *
+ * g2.nodes();
+ * // ['a', 'b']
+ * g2.edges()
+ * // [ { v: 'a', w: 'b' } ]
+ * ```
+ *
+ * @template [GraphLabel=any] - Label of the graph.
+ * @template [NodeLabel=any] - Label of a node.
+ * @template [EdgeLabel=any] - Label of an edge.
+ * @param {GraphJSON<GraphLabel, NodeLabel, EdgeLabel>} json - The JSON representation of the graph.
+ * @returns {Graph<GraphLabel, NodeLabel, EdgeLabel>} The restored graph.
+ */
 function read(json) {
   var g = new Graph(json.options).setGraph(json.value);
   _.each(json.nodes, function (entry) {

--- a/src/graphlib/json.test.js
+++ b/src/graphlib/json.test.js
@@ -57,6 +57,13 @@ describe('json', function () {
   });
 });
 
+/**
+ * @template [GraphLabel=any] - Label of the graph.
+ * @template [NodeLabel=any] - Label of a node.
+ * @template [EdgeLabel=any] - Label of an edge.
+ * @param {Graph<GraphLabel, NodeLabel, EdgeLabel>} g - The graph to serialize and deserialize.
+ * @returns {Graph<GraphLabel, NodeLabel, EdgeLabel>} Copy of g after write and read.
+ */
 function rw(g) {
   return read(write(g));
 }

--- a/test/graphlib/alg/all-shortest-paths.js
+++ b/test/graphlib/alg/all-shortest-paths.js
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { Graph } from '../../../src/graphlib/graph.js';
 
+/**
+ * @import { floydWarshall } from '../../../src/graphlib/alg/index.js';
+ */
+
+/**
+ * @param {typeof floydWarshall} sp - The all-shortest-paths function to test.
+ */
 export function allShortestPathsTests(sp) {
   describe('allShortestPaths', function () {
     it('returns 0 for the node itself', function () {
@@ -121,6 +128,10 @@ export function allShortestPathsTests(sp) {
   });
 }
 
+/**
+ * @param {Graph} g - The graph to generate a weight function for.
+ * @returns {Parameters<typeof floydWarshall>[1]} A weight function for the graph `g`.
+ */
 function weightFn(g) {
   return function (e) {
     return g.edge(e);


### PR DESCRIPTION
On top of #60, this PR also adds JSDoc types to the files in `graphlib/alg`, `graphlib/data`, and `graphlib/json.js`.

I've mostly copied over the documentation from the graphlib wiki, making some minor changes to match the JSDoc/TSDoc tags.

See: https://github.com/dagrejs/graphlib/wiki/API-Reference

CI is failing right now, since it depends on the changes in #60.
